### PR TITLE
feat(#12): 내정보 ui 수정 및 API 연동

### DIFF
--- a/ieum.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ieum.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8bb60b38223a974f680095804ad8a44a74f98919df366516f84223333e42cf68",
+  "originHash" : "32771686551c8883502d363aec92c2790c63ae0187789f023de828223f7d28ed",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "7be73f6c2b5cd90e40798b06ebd5da8f9f79cf88",
         "version" : "5.11.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "1a2b530921ab9d1f4385ced84109b7a86d42cff8",
+        "version" : "2.27.1"
       }
     },
     {

--- a/ieum/Data/Network/DTOs/Profile/UpdateProfileRequest.swift
+++ b/ieum/Data/Network/DTOs/Profile/UpdateProfileRequest.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct UpdateProfileRequest: Codable, Sendable {
+    let diagnoses: [DiagnosisRequest]?
+    let surgery: [SurgeryRequest]?
+    let chemotherapy: [ChemotherapyRequest]?
+    let radiationTherapy: [RadiationTherapyRequest]?
+    let ageGroup: String?
+    let residenceArea: String?
+    let hospitalArea: String?
+    let sexVisible: Bool?
+    let diagnosesVisible: Bool?
+    let surgeryVisible: Bool?
+    let chemotherapyVisible: Bool?
+    let radiationTherapyVisible: Bool?
+    let ageGroupVisible: Bool?
+    let residenceAreaVisible: Bool?
+    let hospitalAreaVisible: Bool?
+}
+
+struct SurgeryRequest: Codable, Sendable {
+    let date: String
+    let description: String
+}
+
+struct ChemotherapyRequest: Codable, Sendable {
+    let startDate: String
+    let endDate: String?
+    let cycle: Int
+}
+
+struct RadiationTherapyRequest: Codable, Sendable {
+    let startDate: String
+    let endDate: String?
+}

--- a/ieum/Data/Repositories/AuthRepository.swift
+++ b/ieum/Data/Repositories/AuthRepository.swift
@@ -8,6 +8,7 @@ protocol AuthRepository {
     func refresh(refreshToken: String) -> AnyPublisher<AppTokenResponse, Error>
     func getProfile() -> AnyPublisher<UserProfile, Error>
     func updateProfile(_ request: UpdateProfileRequest) -> AnyPublisher<UserProfile, Error>
+    func deleteAccount() -> AnyPublisher<Void, Error>
 }
 
 final class AuthRepositoryImpl: AuthRepository {
@@ -117,6 +118,24 @@ final class AuthRepositoryImpl: AuthRepository {
                         parameters: request
                     )
                     promise(.success(response))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    func deleteAccount() -> AnyPublisher<Void, Error> {
+        let endpoint = "/api/v1/users/profile"
+        
+        return Future<Void, Error> { [weak self] promise in
+            guard let self = self else { return }
+            
+            Task {
+                do {
+                    try await self.apiService.requestNoContent(endpoint, method: .delete)
+                    promise(.success(()))
                 } catch {
                     promise(.failure(error))
                 }

--- a/ieum/Data/Repositories/AuthRepository.swift
+++ b/ieum/Data/Repositories/AuthRepository.swift
@@ -7,6 +7,7 @@ protocol AuthRepository {
     func loginWithApple(accessToken: String) -> AnyPublisher<AppLoginResponse, Error>
     func refresh(refreshToken: String) -> AnyPublisher<AppTokenResponse, Error>
     func getProfile() -> AnyPublisher<UserProfile, Error>
+    func updateProfile(_ request: UpdateProfileRequest) -> AnyPublisher<UserProfile, Error>
 }
 
 final class AuthRepositoryImpl: AuthRepository {
@@ -92,6 +93,28 @@ final class AuthRepositoryImpl: AuthRepository {
                     let response: UserProfile = try await self.apiService.request(
                         endpoint,
                         method: .get
+                    )
+                    promise(.success(response))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    func updateProfile(_ request: UpdateProfileRequest) -> AnyPublisher<UserProfile, Error> {
+        let endpoint = "/api/v1/users/profile"
+        
+        return Future<UserProfile, Error> { [weak self] promise in
+            guard let self = self else { return }
+            
+            Task {
+                do {
+                    let response: UserProfile = try await self.apiService.request(
+                        endpoint,
+                        method: .patch,
+                        parameters: request
                     )
                     promise(.success(response))
                 } catch {

--- a/ieum/Data/Repositories/FeedRepository.swift
+++ b/ieum/Data/Repositories/FeedRepository.swift
@@ -5,6 +5,7 @@ import Alamofire
 protocol FeedRepository {
     // 조회
     func fetchPosts(type: PostType, page: Int, pageSize: Int, diagnosis: String?, mood: Int?) -> AnyPublisher<AllPostsResponse, Error>
+    func fetchMyPosts(type: String?, page: Int, pageSize: Int, sort: String?, order: String?, diagnosis: String?, fromDate: String?, toDate: String?) -> AnyPublisher<FeedResponse, Error>
     
     // 작성
     func createWellnessPost(data: CreateWellnessPostData, images: [Data]?) -> AnyPublisher<WellnessPostResponse, Error>
@@ -57,6 +58,47 @@ final class FeedRepositoryImpl: FeedRepository {
             Task {
                 do {
                     let response: AllPostsResponse = try await self.apiService.request(endpoint, method: .get)
+                    promise(.success(response))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
+    func fetchMyPosts(type: String?, page: Int, pageSize: Int, sort: String?, order: String?, diagnosis: String?, fromDate: String?, toDate: String?) -> AnyPublisher<FeedResponse, Error> {
+        var queryItems: [URLQueryItem] = []
+        
+        if let type = type {
+            queryItems.append(URLQueryItem(name: "type", value: type))
+        }
+        queryItems.append(URLQueryItem(name: "page", value: String(page)))
+        queryItems.append(URLQueryItem(name: "pageSize", value: String(pageSize)))
+        if let sort = sort {
+            queryItems.append(URLQueryItem(name: "sort", value: sort))
+        }
+        if let order = order {
+            queryItems.append(URLQueryItem(name: "order", value: order))
+        }
+        if let diagnosis = diagnosis {
+            queryItems.append(URLQueryItem(name: "diagnosis", value: diagnosis))
+        }
+        if let fromDate = fromDate {
+            queryItems.append(URLQueryItem(name: "fromDate", value: fromDate))
+        }
+        if let toDate = toDate {
+            queryItems.append(URLQueryItem(name: "toDate", value: toDate))
+        }
+        
+        var components = URLComponents(string: "/api/v1/users/posts")
+        components?.queryItems = queryItems
+        let endpoint = components?.url?.absoluteString ?? "/api/v1/users/posts"
+        
+        return Future { [weak self] promise in
+            guard let self = self else { return }
+            Task {
+                do {
+                    let response: FeedResponse = try await self.apiService.request(endpoint, method: .get)
                     promise(.success(response))
                 } catch {
                     promise(.failure(error))

--- a/ieum/Global/Colors.swift
+++ b/ieum/Global/Colors.swift
@@ -16,6 +16,7 @@ enum Colors {
         static let s50 = UIColor(hex: "#F8FAFC")
         static let s100 = UIColor(hex: "#F1F5F9")
         static let s200 = UIColor(hex: "#E2E8F0")
+        static let s200Border = UIColor(hex: "#E8EAE4")
         static let s300 = UIColor(hex: "#CBD5E1")
         static let s400 = UIColor(hex: "#94A3B8")
         static let s500 = UIColor(hex: "#64748B")

--- a/ieum/Global/Components/DatePickerInputView.swift
+++ b/ieum/Global/Components/DatePickerInputView.swift
@@ -1,0 +1,219 @@
+import UIKit
+import SnapKit
+import Then
+
+class DatePickerInputView: UIView {
+    
+    // MARK: - Properties
+    
+    var onDateSelected: ((Date) -> Void)?
+    
+    var selectedDate: Date? {
+        didSet {
+            updateDateDisplay()
+        }
+    }
+    
+    /// 선택 가능한 최대 날짜 (기본값: 오늘)
+    var maximumDate: Date? = Date()
+    
+    /// 선택 가능한 최소 날짜
+    var minimumDate: Date?
+    
+    // MARK: - UI Components
+    
+    private let containerView = UIView().then {
+        $0.backgroundColor = Colors.white
+        $0.layer.cornerRadius = 12
+        $0.layer.borderWidth = 1.5
+        $0.layer.borderColor = Colors.black.cgColor
+    }
+    
+    private let dateLabel = UILabel().then {
+        $0.font = .ieum(UIFont.IeumFont.Input.placeholder)
+        $0.textColor = Colors.Gray.g950
+        $0.text = "날짜를 선택해주세요"
+    }
+    
+    private let calendarIconImageView = UIImageView().then {
+        $0.image = UIImage(systemName: "calendar")
+        $0.tintColor = Colors.Gray.g950
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    private let datePicker = UIDatePicker().then {
+        $0.datePickerMode = .date
+        $0.preferredDatePickerStyle = .wheels
+        $0.locale = Locale(identifier: "ko_KR")
+    }
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupLayout()
+        setupActions()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        addSubview(containerView)
+        containerView.addSubview(dateLabel)
+        containerView.addSubview(calendarIconImageView)
+    }
+    
+    private func setupLayout() {
+        containerView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.height.equalTo(74)
+        }
+        
+        dateLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(16)
+            $0.centerY.equalToSuperview()
+            $0.trailing.lessThanOrEqualTo(calendarIconImageView.snp.leading).offset(-8)
+        }
+        
+        calendarIconImageView.snp.makeConstraints {
+            $0.width.height.equalTo(24)
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(16)
+        }
+    }
+    
+    private func setupActions() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapContainer))
+        containerView.addGestureRecognizer(tapGesture)
+        containerView.isUserInteractionEnabled = true
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func didTapContainer() {
+        showDatePicker()
+    }
+    
+    private func showDatePicker() {
+        guard let viewController = self.findViewController() else { return }
+        
+        let sheetVC = DatePickerSheetViewController(
+            selectedDate: selectedDate ?? Date(),
+            minimumDate: minimumDate,
+            maximumDate: maximumDate,
+            onSelect: { [weak self] date in
+                self?.selectedDate = date
+                self?.onDateSelected?(date)
+            }
+        )
+        
+        if let sheet = sheetVC.sheetPresentationController {
+            sheet.detents = [.medium()]
+            sheet.prefersGrabberVisible = true
+            sheet.preferredCornerRadius = 20
+        }
+        
+        viewController.present(sheetVC, animated: true)
+    }
+    
+    private func updateDateDisplay() {
+        guard let date = selectedDate else {
+            dateLabel.text = "날짜를 선택해주세요"
+            dateLabel.textColor = Colors.Slate.s400
+            return
+        }
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy/MM/dd"
+        formatter.locale = Locale(identifier: "ko_KR")
+        
+        dateLabel.text = formatter.string(from: date)
+        dateLabel.textColor = Colors.Gray.g950
+    }
+    
+    private func findViewController() -> UIViewController? {
+        var responder: UIResponder? = self
+        while responder != nil {
+            responder = responder?.next
+            if let viewController = responder as? UIViewController {
+                return viewController
+            }
+            // UICollectionViewCell을 거쳐서 ViewController 찾기
+            if let cell = responder as? UICollectionViewCell {
+                responder = cell.superview
+                while responder != nil {
+                    responder = responder?.next
+                    if let viewController = responder as? UIViewController {
+                        return viewController
+                    }
+                }
+            }
+        }
+        return nil
+    }
+}
+
+// MARK: - DatePickerSheetViewController
+
+private class DatePickerSheetViewController: UIViewController {
+    
+    private let datePicker = UIDatePicker().then {
+        $0.datePickerMode = .date
+        $0.preferredDatePickerStyle = .inline
+        $0.locale = Locale(identifier: "ko_KR")
+    }
+    
+    private let confirmButton = UIButton().then {
+        $0.setTitle("선택", for: .normal)
+        $0.setTitleColor(Colors.white, for: .normal)
+        $0.backgroundColor = Colors.Gray.g950
+        $0.layer.cornerRadius = 12
+        $0.titleLabel?.font = .ieum(UIFont.IeumFont.Heading.h4)
+    }
+    
+    private var onSelect: ((Date) -> Void)?
+    
+    init(selectedDate: Date, minimumDate: Date?, maximumDate: Date?, onSelect: @escaping (Date) -> Void) {
+        super.init(nibName: nil, bundle: nil)
+        self.datePicker.date = selectedDate
+        self.datePicker.minimumDate = minimumDate
+        self.datePicker.maximumDate = maximumDate
+        self.onSelect = onSelect
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = Colors.white
+        
+        view.addSubview(datePicker)
+        view.addSubview(confirmButton)
+        
+        datePicker.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        confirmButton.snp.makeConstraints {
+            $0.top.equalTo(datePicker.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(56)
+            $0.bottom.lessThanOrEqualTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        confirmButton.addTarget(self, action: #selector(didTapConfirm), for: .touchUpInside)
+    }
+    
+    @objc private func didTapConfirm() {
+        onSelect?(datePicker.date)
+        dismiss(animated: true)
+    }
+}

--- a/ieum/Global/Components/IeumCheckbox.swift
+++ b/ieum/Global/Components/IeumCheckbox.swift
@@ -1,0 +1,104 @@
+import UIKit
+import SnapKit
+import Then
+
+class IeumCheckbox: UIView {
+    
+    // MARK: - Properties
+    
+    var onCheckChanged: ((Bool) -> Void)?
+    
+    var isChecked: Bool = false {
+        didSet {
+            updateCheckBoxState()
+            onCheckChanged?(isChecked)
+        }
+    }
+    
+    // MARK: - UI Components
+    
+    private let checkBoxButton = UIButton().then {
+        $0.layer.cornerRadius = 6
+        $0.layer.borderWidth = 1
+        $0.layer.borderColor = Colors.Slate.s300.cgColor
+        $0.backgroundColor = Colors.white
+        $0.setImage(nil, for: .normal)
+    }
+    
+    private let titleLabel = UILabel().then {
+        $0.font = .ieum(UIFont.IeumFont.Text.bodyM)
+        $0.textColor = Colors.Gray.g950
+    }
+    
+    // MARK: - Initializer
+    
+    init(title: String? = nil) {
+        super.init(frame: .zero)
+        titleLabel.text = title
+        setupUI()
+        setupLayout()
+        setupActions()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        addSubview(checkBoxButton)
+        if titleLabel.text != nil {
+            addSubview(titleLabel)
+        }
+    }
+    
+    private func setupLayout() {
+        checkBoxButton.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(24)
+        }
+        
+        if titleLabel.text != nil {
+            titleLabel.snp.makeConstraints {
+                $0.leading.equalTo(checkBoxButton.snp.trailing).offset(8)
+                $0.centerY.equalTo(checkBoxButton)
+                $0.trailing.lessThanOrEqualToSuperview()
+            }
+        }
+        
+        snp.makeConstraints {
+            $0.height.equalTo(24)
+        }
+    }
+    
+    private func setupActions() {
+        checkBoxButton.addTarget(self, action: #selector(didTapCheckBox), for: .touchUpInside)
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapCheckBox))
+        addGestureRecognizer(tapGesture)
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func didTapCheckBox() {
+        isChecked.toggle()
+    }
+    
+    private func updateCheckBoxState() {
+        if isChecked {
+            checkBoxButton.backgroundColor = Colors.Emerald.e600
+            checkBoxButton.layer.borderWidth = 0
+            
+            let config = UIImage.SymbolConfiguration(pointSize: 12, weight: .bold)
+            let checkImage = UIImage(systemName: "checkmark", withConfiguration: config)?.withTintColor(.white, renderingMode: .alwaysOriginal)
+            checkBoxButton.setImage(checkImage, for: .normal)
+        } else {
+            checkBoxButton.backgroundColor = Colors.white
+            checkBoxButton.layer.borderWidth = 1
+            checkBoxButton.layer.borderColor = Colors.Slate.s300.cgColor
+            checkBoxButton.setImage(nil, for: .normal)
+        }
+    }
+}

--- a/ieum/Global/Components/InProgressChip.swift
+++ b/ieum/Global/Components/InProgressChip.swift
@@ -1,0 +1,99 @@
+import UIKit
+import SnapKit
+import Then
+
+class InProgressChip: UIView {
+    
+    // MARK: - Properties
+    
+    var onCheckChanged: ((Bool) -> Void)?
+    
+    var isChecked: Bool = false {
+        didSet {
+            guard oldValue != isChecked else { return }
+            checkbox.isChecked = isChecked
+            updateStyle()
+            onCheckChanged?(isChecked)
+        }
+    }
+    
+    // MARK: - UI Components
+    
+    private let checkbox = IeumCheckbox()
+    
+    private let titleLabel = UILabel().then {
+        $0.text = "진행중이에요"
+        $0.font = .ieum(UIFont.IeumFont.label)
+        $0.textColor = Colors.Gray.g950
+    }
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupLayout()
+        setupActions()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        layer.cornerRadius = 12
+        addSubview(checkbox)
+        addSubview(titleLabel)
+        updateStyle()
+    }
+    
+    private func setupLayout() {
+        checkbox.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(10)
+            $0.centerY.equalToSuperview()
+            $0.width.equalTo(24)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalTo(checkbox.snp.trailing).offset(6)
+            $0.trailing.equalToSuperview().inset(12)
+            $0.centerY.equalToSuperview()
+        }
+        
+        snp.makeConstraints {
+            $0.height.equalTo(32)
+        }
+    }
+    
+    private func setupActions() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapChip))
+        addGestureRecognizer(tapGesture)
+        isUserInteractionEnabled = true
+        
+        checkbox.onCheckChanged = { [weak self] isChecked in
+            guard let self = self, self.isChecked != isChecked else { return }
+            self.isChecked = isChecked
+        }
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func didTapChip() {
+        isChecked.toggle()
+    }
+    
+    private func updateStyle() {
+        if isChecked {
+            backgroundColor = Colors.Gray.g950
+            titleLabel.textColor = Colors.white
+            layer.borderWidth = 0
+        } else {
+            backgroundColor = Colors.white
+            titleLabel.textColor = Colors.Gray.g950
+            layer.borderWidth = 1
+            layer.borderColor = Colors.Gray.g200.cgColor
+        }
+    }
+}

--- a/ieum/Global/Components/PrivacyChip.swift
+++ b/ieum/Global/Components/PrivacyChip.swift
@@ -1,0 +1,105 @@
+import UIKit
+import SnapKit
+import Then
+
+class PrivacyChip: UIView {
+    
+    // MARK: - Properties
+    
+    var onCheckChanged: ((Bool) -> Void)?
+    
+    var isChecked: Bool = false {
+        didSet {
+            updateCheckBoxState()
+            onCheckChanged?(isChecked)
+        }
+    }
+    
+    // MARK: - UI Components
+    
+    private let checkBoxButton = UIButton().then {
+        $0.layer.cornerRadius = 6
+        $0.layer.borderWidth = 1
+        $0.layer.borderColor = Colors.Slate.s300.cgColor
+        $0.backgroundColor = Colors.white
+        $0.setImage(nil, for: .normal)
+    }
+    
+    private let titleLabel = UILabel().then {
+        $0.text = "비공개"
+        $0.font = .ieum(UIFont.IeumFont.label)
+        $0.textColor = Colors.Gray.g950
+    }
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupLayout()
+        setupActions()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        backgroundColor = Colors.white
+        layer.cornerRadius = 12
+        layer.borderWidth = 1
+        layer.borderColor = Colors.Gray.g200.cgColor
+        
+        addSubview(checkBoxButton)
+        addSubview(titleLabel)
+    }
+    
+    private func setupLayout() {
+        checkBoxButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(12)
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(24)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalTo(checkBoxButton.snp.trailing).offset(8)
+            $0.centerY.equalTo(checkBoxButton)
+            $0.trailing.equalToSuperview().inset(12)
+        }
+        
+        snp.makeConstraints {
+            $0.height.equalTo(40)
+        }
+    }
+    
+    private func setupActions() {
+        checkBoxButton.addTarget(self, action: #selector(didTapCheckBox), for: .touchUpInside)
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapCheckBox))
+        addGestureRecognizer(tapGesture)
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func didTapCheckBox() {
+        isChecked.toggle()
+    }
+    
+    private func updateCheckBoxState() {
+        if isChecked {
+            checkBoxButton.backgroundColor = Colors.Emerald.e600
+            checkBoxButton.layer.borderWidth = 0
+            
+            let config = UIImage.SymbolConfiguration(pointSize: 12, weight: .bold)
+            let checkImage = UIImage(systemName: "checkmark", withConfiguration: config)?.withTintColor(.white, renderingMode: .alwaysOriginal)
+            checkBoxButton.setImage(checkImage, for: .normal)
+        } else {
+            checkBoxButton.backgroundColor = Colors.white
+            checkBoxButton.layer.borderWidth = 1
+            checkBoxButton.layer.borderColor = Colors.Slate.s300.cgColor
+            checkBoxButton.setImage(nil, for: .normal)
+        }
+    }
+}

--- a/ieum/Presentation/Auth/SignUp/Step4/View/SignUpStep4ViewController.swift
+++ b/ieum/Presentation/Auth/SignUp/Step4/View/SignUpStep4ViewController.swift
@@ -7,10 +7,14 @@ class SignUpStep4ViewController: UIViewController {
     
     // MARK: - Properties
     
-    weak var coordinator: SignUpCoordinator?
+    weak var coordinator: AnyObject?
     private let viewModel = SignUpStep4ViewModel()
     private var cancellables = Set<AnyCancellable>()
     private var diagnosisButtons: [String: IeumButton] = [:]
+    
+    var isEditMode: Bool = false
+    var onComplete: (([DiagnosisRequest]) -> Void)?
+    private var initialDiagnoses: [UserDiagnosis]?
     
     // MARK: - UI Components
     
@@ -55,6 +59,15 @@ class SignUpStep4ViewController: UIViewController {
         $0.addTarget(self, action: #selector(didTapNext), for: .touchUpInside) // 타겟 추가
     }
     
+    // MARK: - Initializers
+    
+    convenience init(initialDiagnoses: [UserDiagnosis]?, onComplete: @escaping ([DiagnosisRequest]) -> Void) {
+        self.init()
+        self.isEditMode = true
+        self.initialDiagnoses = initialDiagnoses
+        self.onComplete = onComplete
+    }
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -64,6 +77,15 @@ class SignUpStep4ViewController: UIViewController {
         setupUI()
         setupLayout()
         bindViewModel()
+        
+        if isEditMode {
+            stepBadgeChip.isHidden = true
+            titleLabel.text = "진단명 수정"
+            nextButton.setTitle("완료", for: .normal)
+            if let initialDiagnoses = initialDiagnoses {
+                setupInitialDiagnoses(initialDiagnoses)
+            }
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -179,7 +201,9 @@ class SignUpStep4ViewController: UIViewController {
         viewModel.navigateToNext
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                self?.coordinator?.showStep5()
+                if let signUpCoordinator = self?.coordinator as? SignUpCoordinator {
+                    signUpCoordinator.showStep5()
+                }
             }
             .store(in: &cancellables)
     }
@@ -214,10 +238,41 @@ class SignUpStep4ViewController: UIViewController {
     }
     
     private func showStageSelection(for diagnosisName: String) {
-        coordinator?.showStageSelection(cancerName: diagnosisName) { [weak self] stage in
-            guard let self = self else { return }
-            self.viewModel.selectDiagnosis(diagnosisName, stage: stage)
+        if let signUpCoordinator = coordinator as? SignUpCoordinator {
+            signUpCoordinator.showStageSelection(cancerName: diagnosisName) { [weak self] stage in
+                guard let self = self else { return }
+                self.viewModel.selectDiagnosis(diagnosisName, stage: stage)
+            }
+        } else if let myPageCoordinator = coordinator as? MyPageCoordinator {
+            myPageCoordinator.showStageSelection(cancerName: diagnosisName) { [weak self] stage in
+                guard let self = self else { return }
+                self.viewModel.selectDiagnosis(diagnosisName, stage: stage)
+            }
         }
+    }
+    
+    private func setupInitialDiagnoses(_ diagnoses: [UserDiagnosis]) {
+        var selectedDiagnosis: [String: String] = [:]
+        for diagnosis in diagnoses {
+            let title: String
+            switch diagnosis.diagnosis {
+            case "rectal_cancer": title = "직장암"
+            case "colon_cancer": title = "대장암"
+            case "liver_transplant": title = "간이식"
+            case "others": title = "기타"
+            default: title = "기타"
+            }
+            if let stage = diagnosis.cancerStage {
+                selectedDiagnosis[title] = "\(stage)기"
+            } else {
+                selectedDiagnosis[title] = ""
+            }
+        }
+        
+        for (title, stage) in selectedDiagnosis {
+            viewModel.selectDiagnosis(title, stage: stage)
+        }
+        viewModel.updateState()
     }
     
     // MARK: - Actions
@@ -228,7 +283,19 @@ class SignUpStep4ViewController: UIViewController {
     }
     
     @objc private func didTapNext() {
-        viewModel.didTapNext.send()
+        if isEditMode {
+            let diagnoses = viewModel.selectedDiagnosis.map { (key, value) -> DiagnosisRequest in
+                let stage: Int? = (value.isEmpty) ? nil : Int(value.replacingOccurrences(of: "기", with: ""))
+                var diagnosisType: DiagnosisType = .others
+                if key == "직장암" { diagnosisType = .rectalCancer }
+                else if key == "대장암" { diagnosisType = .colonCancer }
+                else if key == "간이식" { diagnosisType = .liverTransplant }
+                return DiagnosisRequest(diagnosis: diagnosisType, cancerStage: stage)
+            }
+            onComplete?(diagnoses)
+        } else {
+            viewModel.didTapNext.send()
+        }
     }
 }
 

--- a/ieum/Presentation/Auth/SignUp/Step4/ViewModel/SignUpStep4ViewModel.swift
+++ b/ieum/Presentation/Auth/SignUp/Step4/ViewModel/SignUpStep4ViewModel.swift
@@ -63,7 +63,7 @@ final class SignUpStep4ViewModel: ObservableObject {
         updateState()
     }
     
-    private func updateState() {
+    func updateState() {
         let count = selectedDiagnosis.count
         selectedCount = count
         

--- a/ieum/Presentation/Auth/SignUp/Step5/View/SignUpStep5ViewController.swift
+++ b/ieum/Presentation/Auth/SignUp/Step5/View/SignUpStep5ViewController.swift
@@ -11,6 +11,10 @@ class SignUpStep5ViewController: UIViewController {
     private let viewModel = SignUpStep5ViewModel()
     private var cancellables = Set<AnyCancellable>()
     
+    var isEditMode: Bool = false
+    var onComplete: ((String?) -> Void)?
+    private var initialAgeGroup: String?
+    
     // MARK: - UI Components
     
     private let stepBadgeChip = IeumChip(title: "4 / 7", type: .static).then {
@@ -58,16 +62,36 @@ class SignUpStep5ViewController: UIViewController {
     
     private var buttons: [IeumButton] = []
     
+    // MARK: - Initializers
+    
+    convenience init(initialAgeGroup: String?, onComplete: @escaping (String?) -> Void) {
+        self.init()
+        self.isEditMode = true
+        self.initialAgeGroup = initialAgeGroup
+        self.onComplete = onComplete
+    }
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = Colors.ieumBackground // FBFDF4
+        view.backgroundColor = Colors.ieumBackground
         
         setupUI()
         setupLayout()
         setupActions()
         bindViewModel()
+        
+        if isEditMode {
+            stepBadgeChip.isHidden = true
+            titleLabel.text = "연령대 수정"
+            skipButton.isHidden = true
+            nextButton.setTitle("완료", for: .normal)
+            bottomStackView.distribution = .fill
+            if let initialAgeGroup = initialAgeGroup {
+                setupInitialAgeGroup(initialAgeGroup)
+            }
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -167,7 +191,20 @@ class SignUpStep5ViewController: UIViewController {
     }
     
     @objc private func didTapNext() {
-        viewModel.didTapNext.send()
+        if isEditMode {
+            let ageGroup = viewModel.selectedAgeGroup.flatMap { title in
+                AgeGroup.allCases.first(where: { $0.title == title })?.rawValue
+            }
+            onComplete?(ageGroup)
+        } else {
+            viewModel.didTapNext.send()
+        }
+    }
+    
+    private func setupInitialAgeGroup(_ ageGroup: String) {
+        if let ageGroupTitle = AgeGroup.allCases.first(where: { $0.rawValue == ageGroup })?.title {
+            viewModel.didSelectAgeGroup.send(ageGroupTitle)
+        }
     }
 }
 

--- a/ieum/Presentation/Auth/SignUp/Step6/View/SignUpStep6ViewController.swift
+++ b/ieum/Presentation/Auth/SignUp/Step6/View/SignUpStep6ViewController.swift
@@ -11,6 +11,10 @@ class SignUpStep6ViewController: UIViewController {
     private let viewModel = SignUpStep6ViewModel()
     private var cancellables = Set<AnyCancellable>()
     
+    var isEditMode: Bool = false
+    var onComplete: ((String?) -> Void)?
+    private var initialResidenceArea: String?
+    
     // MARK: - UI Components
     
     private let stepBadgeChip = IeumChip(title: "5 / 7", type: .static).then {
@@ -92,6 +96,15 @@ class SignUpStep6ViewController: UIViewController {
         return viewModel.currentDistricts
     }
     
+    // MARK: - Initializers
+    
+    convenience init(initialResidenceArea: String?, onComplete: @escaping (String?) -> Void) {
+        self.init()
+        self.isEditMode = true
+        self.initialResidenceArea = initialResidenceArea
+        self.onComplete = onComplete
+    }
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -104,9 +117,20 @@ class SignUpStep6ViewController: UIViewController {
         setupActions()
         bindViewModel()
         
-        // 초기 선택 상태 (서울)
-        DispatchQueue.main.async { [weak self] in
-            self?.cityTableView.selectRow(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .top)
+        if isEditMode {
+            stepBadgeChip.isHidden = true
+            titleLabel.text = "거주 지역 수정"
+            skipButton.isHidden = true
+            nextButton.setTitle("완료", for: .normal)
+            bottomStackView.distribution = .fill
+            if let initialResidenceArea = initialResidenceArea {
+                setupInitialResidenceArea(initialResidenceArea)
+            }
+        } else {
+            // 초기 선택 상태 (서울)
+            DispatchQueue.main.async { [weak self] in
+                self?.cityTableView.selectRow(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .top)
+            }
         }
     }
     
@@ -270,7 +294,36 @@ class SignUpStep6ViewController: UIViewController {
     }
     
     @objc private func didTapNext() {
-        viewModel.didTapNext.send()
+        if isEditMode {
+            let selectedArea: String?
+            if let cityIndex = viewModel.selectedCityIndex,
+               let districtIndex = viewModel.selectedDistrictIndex,
+               cityIndex < viewModel.cities.count,
+               districtIndex < viewModel.currentDistricts.count {
+                selectedArea = "\(viewModel.cities[cityIndex]) \(viewModel.currentDistricts[districtIndex])"
+            } else {
+                selectedArea = nil
+            }
+            onComplete?(selectedArea)
+        } else {
+            viewModel.didTapNext.send()
+        }
+    }
+    
+    private func setupInitialResidenceArea(_ residenceArea: String) {
+        let components = residenceArea.split(separator: " ").map(String.init)
+        if components.count >= 2 {
+            let city = components[0]
+            let district = components[1]
+            if let cityIndex = viewModel.cities.firstIndex(of: city) {
+                viewModel.didSelectCity.send(cityIndex)
+                if let districtIndex = viewModel.districts[city]?.firstIndex(of: district) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                        self?.viewModel.didSelectDistrict.send(districtIndex)
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/ieum/Presentation/Coordinator/AppCoordinator.swift
+++ b/ieum/Presentation/Coordinator/AppCoordinator.swift
@@ -24,12 +24,34 @@ final class AppCoordinator: Coordinator {
         window.rootViewController = navigationController
         window.makeKeyAndVisible()
         
+        // 로그아웃 알림 관찰
+        observeLogout()
+        
         // 개발 모드인 경우 바로 메인 화면으로 이동
         if isDevelopmentMode {
             showMain()
         } else {
             showSplash()
         }
+    }
+    
+    private func observeLogout() {
+        NotificationCenter.default.publisher(for: .userDidLogout)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.handleLogout()
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func handleLogout() {
+        // 네비게이션 스택 초기화
+        navigationController = UINavigationController()
+        window.rootViewController = navigationController
+        childCoordinators.removeAll()
+        
+        // 로그인 화면으로 이동
+        showAuth()
     }
     
     private func showSplash() {

--- a/ieum/Presentation/Coordinator/MyPageCoordinator.swift
+++ b/ieum/Presentation/Coordinator/MyPageCoordinator.swift
@@ -142,14 +142,116 @@ final class MyPageCoordinator: Coordinator {
     }
     
     func showEditSurgery(profile: UserProfile) {
-        // TODO: 수술 이력 수정 UI 구현 필요
+        let editVC = SurgeryHistoryViewController(
+            initialSurgeries: profile.surgery,
+            onComplete: { [weak self] surgeries, isPrivate in
+                guard let self = self, let viewModel = self.viewModel else { return }
+                let request = viewModel.createUpdateRequest(
+                    from: profile,
+                    updatingSurgery: surgeries.isEmpty ? [] : surgeries
+                )
+                let updatedRequest = UpdateProfileRequest(
+                    diagnoses: request.diagnoses,
+                    surgery: surgeries.isEmpty ? [] : surgeries,
+                    chemotherapy: request.chemotherapy,
+                    radiationTherapy: request.radiationTherapy,
+                    ageGroup: request.ageGroup,
+                    residenceArea: request.residenceArea,
+                    hospitalArea: request.hospitalArea,
+                    sexVisible: request.sexVisible,
+                    diagnosesVisible: request.diagnosesVisible,
+                    surgeryVisible: isPrivate ? false : request.surgeryVisible,
+                    chemotherapyVisible: request.chemotherapyVisible,
+                    radiationTherapyVisible: request.radiationTherapyVisible,
+                    ageGroupVisible: request.ageGroupVisible,
+                    residenceAreaVisible: request.residenceAreaVisible,
+                    hospitalAreaVisible: request.hospitalAreaVisible
+                )
+                viewModel.updateProfile(updatedRequest)
+                    .sink(
+                        receiveCompletion: { _ in },
+                        receiveValue: { _ in }
+                    )
+                    .store(in: &self.cancellables)
+            }
+        )
+        editVC.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(editVC, animated: true)
     }
     
     func showEditChemotherapy(profile: UserProfile) {
-        // TODO: 항암 이력 수정 UI 구현 필요
+        let editVC = ChemotherapyHistoryViewController(
+            initialChemotherapies: profile.chemotherapy,
+            onComplete: { [weak self] chemotherapies, isPrivate in
+                guard let self = self, let viewModel = self.viewModel else { return }
+                let request = viewModel.createUpdateRequest(
+                    from: profile,
+                    updatingChemotherapy: chemotherapies.isEmpty ? [] : chemotherapies
+                )
+                let updatedRequest = UpdateProfileRequest(
+                    diagnoses: request.diagnoses,
+                    surgery: request.surgery,
+                    chemotherapy: chemotherapies.isEmpty ? [] : chemotherapies,
+                    radiationTherapy: request.radiationTherapy,
+                    ageGroup: request.ageGroup,
+                    residenceArea: request.residenceArea,
+                    hospitalArea: request.hospitalArea,
+                    sexVisible: request.sexVisible,
+                    diagnosesVisible: request.diagnosesVisible,
+                    surgeryVisible: request.surgeryVisible,
+                    chemotherapyVisible: isPrivate ? false : request.chemotherapyVisible,
+                    radiationTherapyVisible: request.radiationTherapyVisible,
+                    ageGroupVisible: request.ageGroupVisible,
+                    residenceAreaVisible: request.residenceAreaVisible,
+                    hospitalAreaVisible: request.hospitalAreaVisible
+                )
+                viewModel.updateProfile(updatedRequest)
+                    .sink(
+                        receiveCompletion: { _ in },
+                        receiveValue: { _ in }
+                    )
+                    .store(in: &self.cancellables)
+            }
+        )
+        editVC.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(editVC, animated: true)
     }
     
     func showEditRadiation(profile: UserProfile) {
-        // TODO: 방사선 이력 수정 UI 구현 필요
+        let editVC = RadiationHistoryViewController(
+            initialRadiations: profile.radiationTherapy,
+            onComplete: { [weak self] radiations, isPrivate in
+                guard let self = self, let viewModel = self.viewModel else { return }
+                let request = viewModel.createUpdateRequest(
+                    from: profile,
+                    updatingRadiationTherapy: radiations.isEmpty ? [] : radiations
+                )
+                let updatedRequest = UpdateProfileRequest(
+                    diagnoses: request.diagnoses,
+                    surgery: request.surgery,
+                    chemotherapy: request.chemotherapy,
+                    radiationTherapy: radiations.isEmpty ? [] : radiations,
+                    ageGroup: request.ageGroup,
+                    residenceArea: request.residenceArea,
+                    hospitalArea: request.hospitalArea,
+                    sexVisible: request.sexVisible,
+                    diagnosesVisible: request.diagnosesVisible,
+                    surgeryVisible: request.surgeryVisible,
+                    chemotherapyVisible: request.chemotherapyVisible,
+                    radiationTherapyVisible: isPrivate ? false : request.radiationTherapyVisible,
+                    ageGroupVisible: request.ageGroupVisible,
+                    residenceAreaVisible: request.residenceAreaVisible,
+                    hospitalAreaVisible: request.hospitalAreaVisible
+                )
+                viewModel.updateProfile(updatedRequest)
+                    .sink(
+                        receiveCompletion: { _ in },
+                        receiveValue: { _ in }
+                    )
+                    .store(in: &self.cancellables)
+            }
+        )
+        editVC.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(editVC, animated: true)
     }
 }

--- a/ieum/Presentation/Coordinator/MyPageCoordinator.swift
+++ b/ieum/Presentation/Coordinator/MyPageCoordinator.swift
@@ -10,6 +10,7 @@ final class MyPageCoordinator: Coordinator {
     var navigationController: UINavigationController
     
     weak var delegate: MyPageCoordinatorDelegate?
+    private weak var viewModel: MyPageViewModel?
     private var cancellables = Set<AnyCancellable>()
     
     init(navigationController: UINavigationController) {
@@ -19,6 +20,7 @@ final class MyPageCoordinator: Coordinator {
     func start() {
         let viewModel = MyPageViewModel()
         let postsViewModel = MyPostsViewModel()
+        self.viewModel = viewModel
         
         // Setup navigation actions
         viewModel.didTapEditProfile
@@ -29,7 +31,8 @@ final class MyPageCoordinator: Coordinator {
             
         viewModel.didTapInfoSection
             .sink { [weak self] sectionType in
-                self?.showInfoDetail()
+                guard let self = self, let profile = viewModel.userProfile else { return }
+                self.showEditSection(sectionType: sectionType, profile: profile)
             }
             .store(in: &cancellables)
             
@@ -55,5 +58,98 @@ final class MyPageCoordinator: Coordinator {
     
     func showPostDetail(postId: Int) {
         print("Show Post Detail: \(postId)")
+    }
+    
+    func showEditSection(sectionType: InfoSectionType, profile: UserProfile) {
+        switch sectionType {
+        case .diagnosis:
+            showEditDiagnosis(profile: profile)
+        case .surgery:
+            showEditSurgery(profile: profile)
+        case .chemotherapy:
+            showEditChemotherapy(profile: profile)
+        case .radiation:
+            showEditRadiation(profile: profile)
+        case .ageGroup:
+            showEditAgeGroup(profile: profile)
+        case .residence:
+            showEditRegion(profile: profile)
+        }
+    }
+    
+    func showEditDiagnosis(profile: UserProfile) {
+        let editVC = SignUpStep4ViewController(
+            initialDiagnoses: profile.diagnoses,
+            onComplete: { [weak self] diagnoses in
+                guard let self = self, let viewModel = self.viewModel else { return }
+                let request = viewModel.createUpdateRequest(from: profile, updatingDiagnoses: diagnoses)
+                viewModel.updateProfile(request)
+                    .sink(
+                        receiveCompletion: { _ in },
+                        receiveValue: { _ in }
+                    )
+                    .store(in: &self.cancellables)
+                self.navigationController.popViewController(animated: true)
+            }
+        )
+        editVC.coordinator = self
+        editVC.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(editVC, animated: true)
+    }
+    
+    func showEditAgeGroup(profile: UserProfile) {
+        let editVC = SignUpStep5ViewController(
+            initialAgeGroup: profile.ageGroup,
+            onComplete: { [weak self] ageGroup in
+                guard let self = self, let viewModel = self.viewModel else { return }
+                let request = viewModel.createUpdateRequest(from: profile, updatingAgeGroup: ageGroup)
+                viewModel.updateProfile(request)
+                    .sink(
+                        receiveCompletion: { _ in },
+                        receiveValue: { _ in }
+                    )
+                    .store(in: &self.cancellables)
+                self.navigationController.popViewController(animated: true)
+            }
+        )
+        editVC.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(editVC, animated: true)
+    }
+    
+    func showEditRegion(profile: UserProfile) {
+        let editVC = SignUpStep6ViewController(
+            initialResidenceArea: profile.residenceArea,
+            onComplete: { [weak self] residenceArea in
+                guard let self = self, let viewModel = self.viewModel else { return }
+                let request = viewModel.createUpdateRequest(from: profile, updatingResidenceArea: residenceArea)
+                viewModel.updateProfile(request)
+                    .sink(
+                        receiveCompletion: { _ in },
+                        receiveValue: { _ in }
+                    )
+                    .store(in: &self.cancellables)
+                self.navigationController.popViewController(animated: true)
+            }
+        )
+        editVC.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(editVC, animated: true)
+    }
+    
+    func showStageSelection(cancerName: String, onSelect: @escaping (String) -> Void) {
+        let viewController = StageSelectionViewController(cancerName: cancerName)
+        viewController.onSelect = onSelect
+        navigationController.present(viewController, animated: true)
+    }
+    
+    func showEditSurgery(profile: UserProfile) {
+        // TODO: 수술 이력 수정 UI 구현 필요
+    }
+    
+    func showEditChemotherapy(profile: UserProfile) {
+        // TODO: 항암 이력 수정 UI 구현 필요
+    }
+    
+    func showEditRadiation(profile: UserProfile) {
+        // TODO: 방사선 이력 수정 UI 구현 필요
     }
 }

--- a/ieum/Presentation/Coordinator/MyPageCoordinator.swift
+++ b/ieum/Presentation/Coordinator/MyPageCoordinator.swift
@@ -5,6 +5,11 @@ protocol MyPageCoordinatorDelegate: AnyObject {
     // 마이페이지 흐름 종료 시 (필요 시)
 }
 
+// 로그아웃/회원탈퇴 시 로그인 화면 전환을 위한 Notification
+extension Notification.Name {
+    static let userDidLogout = Notification.Name("userDidLogout")
+}
+
 final class MyPageCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
     var navigationController: UINavigationController
@@ -12,6 +17,7 @@ final class MyPageCoordinator: Coordinator {
     weak var delegate: MyPageCoordinatorDelegate?
     private weak var viewModel: MyPageViewModel?
     private var cancellables = Set<AnyCancellable>()
+    private let authRepository: AuthRepository = AuthRepositoryImpl()
     
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -253,5 +259,49 @@ final class MyPageCoordinator: Coordinator {
         )
         editVC.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(editVC, animated: true)
+    }
+    
+    // MARK: - Settings
+    
+    func showSettings() {
+        let settingsVC = SettingsViewController()
+        settingsVC.delegate = self
+        settingsVC.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(settingsVC, animated: true)
+    }
+}
+
+// MARK: - SettingsViewControllerDelegate
+
+extension MyPageCoordinator: SettingsViewControllerDelegate {
+    func didTapPrivacyPolicy() {
+        let privacyVC = PrivacyPolicyViewController()
+        privacyVC.hidesBottomBarWhenPushed = true
+        navigationController.pushViewController(privacyVC, animated: true)
+    }
+    
+    func didTapDeleteAccount() {
+        authRepository.deleteAccount()
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                if case .failure(let error) = completion {
+                    print("Delete account error: \(error)")
+                }
+            } receiveValue: { [weak self] _ in
+                self?.handleLogout()
+            }
+            .store(in: &cancellables)
+    }
+    
+    func didTapLogout() {
+        handleLogout()
+    }
+    
+    private func handleLogout() {
+        // 토큰 삭제
+        TokenManager.shared.clearTokens()
+        
+        // 로그인 화면으로 전환 알림
+        NotificationCenter.default.post(name: .userDidLogout, object: nil)
     }
 }

--- a/ieum/Presentation/Main/MyPage/Model/HistoryItemModels.swift
+++ b/ieum/Presentation/Main/MyPage/Model/HistoryItemModels.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct SurgeryHistoryItem {
+    var date: Date?
+    var description: String
+}
+
+struct ChemotherapyHistoryItem {
+    var cycle: Int
+    var startDate: Date?
+    var endDate: Date?
+    var isInProgress: Bool
+}
+
+struct RadiationHistoryItem {
+    var startDate: Date?
+    var endDate: Date?
+    var isInProgress: Bool
+}

--- a/ieum/Presentation/Main/MyPage/View/ChemotherapyHistoryViewController.swift
+++ b/ieum/Presentation/Main/MyPage/View/ChemotherapyHistoryViewController.swift
@@ -1,0 +1,230 @@
+import UIKit
+import SnapKit
+import Then
+import Combine
+
+final class ChemotherapyHistoryViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    private let viewModel = ChemotherapyHistoryViewModel()
+    private var cancellables = Set<AnyCancellable>()
+    
+    var onComplete: (([ChemotherapyRequest], Bool) -> Void)?
+    private var initialChemotherapies: [Chemotherapy]?
+    
+    // MARK: - UI Components
+    
+    private let titleLabel = UILabel().then {
+        $0.text = "받으신 항암치료를\n알려주세요"
+        $0.font = .ieum(UIFont.IeumFont.Heading.h1)
+        $0.textColor = Colors.Gray.g950
+        $0.numberOfLines = 0
+    }
+    
+    private let collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 20
+        layout.minimumInteritemSpacing = 0
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+        layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = Colors.Slate.s50
+        collectionView.showsVerticalScrollIndicator = false
+        return collectionView
+    }()
+    
+    private let addButton = IeumButton(title: "항암이력 추가 +").then {
+        $0.setStyle(backgroundColor: Colors.Gray.g200, titleColor: Colors.Gray.g600, for: .normal)
+    }
+    
+    private let privacyChip = PrivacyChip()
+    
+    private let completeButton = IeumButton(title: "완료").then {
+        $0.setStyle(backgroundColor: Colors.Lime.l100, titleColor: Colors.Gray.g950, for: .normal)
+        $0.setStyle(backgroundColor: Colors.Gray.g200, titleColor: Colors.Gray.g400, for: .disabled)
+        $0.layer.borderWidth = 1.5
+        $0.layer.borderColor = Colors.Lime.l200.cgColor
+        $0.isEnabled = false
+    }
+    
+    // MARK: - Initializer
+    
+    convenience init(initialChemotherapies: [Chemotherapy]?, onComplete: @escaping ([ChemotherapyRequest], Bool) -> Void) {
+        self.init()
+        self.initialChemotherapies = initialChemotherapies
+        self.onComplete = onComplete
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = Colors.Slate.s50
+        
+        setupUI()
+        setupLayout()
+        setupCollectionView()
+        bindViewModel()
+        
+        if let initialChemotherapies = initialChemotherapies {
+            viewModel.setupInitialData(initialChemotherapies)
+        } else {
+            viewModel.didTapAddHistory.send()
+        }
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupNavigationBar()
+    }
+    
+    // MARK: - Setup
+    
+    private func setupNavigationBar() {
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = Colors.Slate.s50
+        appearance.shadowColor = .clear
+        
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.tintColor = Colors.Gray.g950
+        
+        let backItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        navigationController?.navigationBar.topItem?.backBarButtonItem = backItem
+    }
+    
+    private func setupUI() {
+        view.addSubview(titleLabel)
+        view.addSubview(collectionView)
+        view.addSubview(addButton)
+        view.addSubview(privacyChip)
+        view.addSubview(completeButton)
+    }
+    
+    private func setupLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+            $0.leading.equalToSuperview().offset(20)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+        
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(24)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(addButton.snp.top).offset(-16)
+        }
+        
+        addButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalTo(privacyChip.snp.top).offset(-16)
+            $0.height.equalTo(56)
+        }
+        
+        privacyChip.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(completeButton.snp.top).offset(-16)
+        }
+        
+        completeButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.height.equalTo(72)
+        }
+    }
+    
+    private func setupCollectionView() {
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.register(ChemotherapyHistoryCell.self, forCellWithReuseIdentifier: ChemotherapyHistoryCell.identifier)
+    }
+    
+    private func bindViewModel() {
+        addButton.addTarget(self, action: #selector(didTapAdd), for: .touchUpInside)
+        completeButton.addTarget(self, action: #selector(didTapComplete), for: .touchUpInside)
+        
+        privacyChip.onCheckChanged = { [weak self] isChecked in
+            self?.viewModel.didChangePrivacy.send(isChecked)
+        }
+        
+        viewModel.$historyItems
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.collectionView.reloadData()
+            }
+            .store(in: &cancellables)
+        
+        viewModel.$isCompleteButtonEnabled
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.isEnabled, on: completeButton)
+            .store(in: &cancellables)
+        
+        viewModel.navigateToComplete
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] chemotherapies, isPrivate in
+                self?.onComplete?(chemotherapies, isPrivate)
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func didTapAdd() {
+        viewModel.didTapAddHistory.send()
+    }
+    
+    @objc private func didTapComplete() {
+        viewModel.didTapComplete.send()
+    }
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension ChemotherapyHistoryViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return viewModel.historyItems.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ChemotherapyHistoryCell.identifier, for: indexPath) as? ChemotherapyHistoryCell else {
+            return UICollectionViewCell()
+        }
+        
+        let item = viewModel.historyItems[indexPath.item]
+        cell.configure(cycle: item.cycle, startDate: item.startDate, endDate: item.endDate, isInProgress: item.isInProgress)
+        
+        cell.onDelete = { [weak self] in
+            self?.viewModel.didTapDeleteHistory.send(indexPath.item)
+        }
+        
+        cell.onCycleChanged = { [weak self] cycle in
+            self?.viewModel.didUpdateCycle.send((index: indexPath.item, cycle: cycle))
+        }
+        
+        cell.onStartDateChanged = { [weak self] date in
+            self?.viewModel.didUpdateStartDate.send((index: indexPath.item, date: date))
+        }
+        
+        cell.onEndDateChanged = { [weak self] date in
+            self?.viewModel.didUpdateEndDate.send((index: indexPath.item, date: date))
+        }
+        
+        cell.onInProgressChanged = { [weak self] isInProgress in
+            self?.viewModel.didToggleInProgress.send((index: indexPath.item, isInProgress: isInProgress))
+        }
+        
+        return cell
+    }
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension ChemotherapyHistoryViewController: UICollectionViewDelegate {
+    // Delegate methods can be added here if needed
+}
+

--- a/ieum/Presentation/Main/MyPage/View/Components/ChemotherapyHistoryCell.swift
+++ b/ieum/Presentation/Main/MyPage/View/Components/ChemotherapyHistoryCell.swift
@@ -1,0 +1,210 @@
+import UIKit
+import SnapKit
+import Then
+
+final class ChemotherapyHistoryCell: UICollectionViewCell {
+    
+    static let identifier = "ChemotherapyHistoryCell"
+    
+    // MARK: - Properties
+    
+    var onDelete: (() -> Void)?
+    var onCycleChanged: ((Int) -> Void)?
+    var onStartDateChanged: ((Date) -> Void)?
+    var onEndDateChanged: ((Date) -> Void)?
+    var onInProgressChanged: ((Bool) -> Void)?
+    
+    // MARK: - UI Components
+    
+    private let containerView = UIView().then {
+        $0.backgroundColor = Colors.white
+        $0.layer.cornerRadius = 16
+        $0.layer.borderWidth = 1
+        $0.layer.borderColor = Colors.Slate.s200Border.cgColor
+    }
+    
+    private let stackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 12
+        $0.alignment = .fill
+        $0.distribution = .fill
+    }
+    
+    private let cycleLabel = UILabel().then {
+        $0.text = "차수"
+        $0.font = .ieum(UIFont.IeumFont.Heading.h5)
+        $0.textColor = Colors.Gray.g950
+    }
+    
+    private let cycleTextField = UITextField().then {
+        $0.font = .ieum(UIFont.IeumFont.Heading.h5)
+        $0.textColor = Colors.Gray.g950
+        $0.keyboardType = .numberPad
+        $0.layer.borderWidth = 1.5
+        $0.layer.borderColor = Colors.black.cgColor
+        $0.layer.cornerRadius = 12
+        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: 0))
+        $0.leftViewMode = .always
+        $0.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: 0))
+        $0.rightViewMode = .always
+    }
+    
+    private let startDateLabel = UILabel().then {
+        $0.text = "시작날짜"
+        $0.font = .ieum(UIFont.IeumFont.Heading.h5)
+        $0.textColor = Colors.Gray.g950
+    }
+    
+    private let startDatePickerInputView = DatePickerInputView()
+    
+    private let endDateContainerView = UIView()
+    
+    private let endDateLabel = UILabel().then {
+        $0.text = "종료날짜"
+        $0.font = .ieum(UIFont.IeumFont.Heading.h5)
+        $0.textColor = Colors.Gray.g950
+    }
+    
+    private let endDatePickerInputView = DatePickerInputView()
+    
+    private let inProgressChip = InProgressChip()
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupLayout()
+        setupActions()
+        setupSwipeGesture()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        contentView.addSubview(containerView)
+        containerView.addSubview(stackView)
+        
+        stackView.addArrangedSubview(cycleLabel)
+        stackView.addArrangedSubview(cycleTextField)
+        stackView.addArrangedSubview(startDateLabel)
+        stackView.addArrangedSubview(startDatePickerInputView)
+        
+        endDateContainerView.addSubview(endDateLabel)
+        endDateContainerView.addSubview(endDatePickerInputView)
+        endDateContainerView.addSubview(inProgressChip)
+        stackView.addArrangedSubview(endDateContainerView)
+    }
+    
+    private func setupLayout() {
+        contentView.snp.makeConstraints {
+            $0.width.equalTo(UIScreen.main.bounds.width - 40)
+        }
+        
+        containerView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(20)
+        }
+        
+        cycleTextField.snp.makeConstraints {
+            $0.height.equalTo(74)
+        }
+        
+        endDateLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.top.equalToSuperview()
+        }
+        
+        endDatePickerInputView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.top.equalTo(endDateLabel.snp.bottom).offset(12)
+            $0.bottom.equalToSuperview()
+        }
+        
+        inProgressChip.snp.makeConstraints {
+            $0.trailing.equalToSuperview()
+            $0.centerY.equalTo(endDateLabel)
+        }
+    }
+    
+    private func setupActions() {
+        cycleTextField.addTarget(self, action: #selector(cycleTextFieldDidChange), for: .editingChanged)
+        
+        startDatePickerInputView.onDateSelected = { [weak self] date in
+            self?.onStartDateChanged?(date)
+        }
+        
+        endDatePickerInputView.onDateSelected = { [weak self] date in
+            self?.onEndDateChanged?(date)
+        }
+        
+        inProgressChip.onCheckChanged = { [weak self] isChecked in
+            self?.updateEndDateEnabled(!isChecked)
+            self?.onInProgressChanged?(isChecked)
+        }
+    }
+    
+    @objc private func cycleTextFieldDidChange() {
+        if let text = cycleTextField.text, let cycle = Int(text) {
+            onCycleChanged?(cycle)
+        }
+    }
+    
+    private func setupSwipeGesture() {
+        let swipeGesture = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipe))
+        swipeGesture.direction = .left
+        addGestureRecognizer(swipeGesture)
+    }
+    
+    private func updateEndDateEnabled(_ enabled: Bool) {
+        endDatePickerInputView.isUserInteractionEnabled = enabled
+        endDatePickerInputView.alpha = enabled ? 1.0 : 0.5
+    }
+    
+    @objc private func handleSwipe() {
+        showDeleteConfirmation()
+    }
+    
+    private func showDeleteConfirmation() {
+        let alert = UIAlertController(title: "삭제", message: "이 항암 이력을 삭제하시겠습니까?", preferredStyle: .alert)
+        
+        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+            self?.onDelete?()
+        }
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+        alert.addAction(deleteAction)
+        alert.addAction(cancelAction)
+        
+        if let viewController = self.findViewController() {
+            viewController.present(alert, animated: true)
+        }
+    }
+    
+    func configure(cycle: Int, startDate: Date?, endDate: Date?, isInProgress: Bool) {
+        cycleTextField.text = "\(cycle)"
+        startDatePickerInputView.selectedDate = startDate
+        endDatePickerInputView.selectedDate = endDate
+        inProgressChip.isChecked = isInProgress
+        updateEndDateEnabled(!isInProgress)
+    }
+    
+    private func findViewController() -> UIViewController? {
+        var responder: UIResponder? = self
+        while responder != nil {
+            responder = responder?.next
+            if let viewController = responder as? UIViewController {
+                return viewController
+            }
+        }
+        return nil
+    }
+}

--- a/ieum/Presentation/Main/MyPage/View/Components/RadiationHistoryCell.swift
+++ b/ieum/Presentation/Main/MyPage/View/Components/RadiationHistoryCell.swift
@@ -1,0 +1,175 @@
+import UIKit
+import SnapKit
+import Then
+
+final class RadiationHistoryCell: UICollectionViewCell {
+    
+    static let identifier = "RadiationHistoryCell"
+    
+    // MARK: - Properties
+    
+    var onDelete: (() -> Void)?
+    var onStartDateChanged: ((Date) -> Void)?
+    var onEndDateChanged: ((Date) -> Void)?
+    var onInProgressChanged: ((Bool) -> Void)?
+    
+    // MARK: - UI Components
+    
+    private let containerView = UIView().then {
+        $0.backgroundColor = Colors.white
+        $0.layer.cornerRadius = 16
+        $0.layer.borderWidth = 1
+        $0.layer.borderColor = Colors.Slate.s200Border.cgColor
+    }
+    
+    private let stackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 12
+        $0.alignment = .fill
+        $0.distribution = .fill
+    }
+    
+    private let startDateLabel = UILabel().then {
+        $0.text = "시작날짜"
+        $0.font = .ieum(UIFont.IeumFont.Heading.h5)
+        $0.textColor = Colors.Gray.g950
+    }
+    
+    private let startDatePickerInputView = DatePickerInputView()
+    
+    private let endDateContainerView = UIView()
+    
+    private let endDateLabel = UILabel().then {
+        $0.text = "종료날짜"
+        $0.font = .ieum(UIFont.IeumFont.Heading.h5)
+        $0.textColor = Colors.Gray.g950
+    }
+    
+    private let endDatePickerInputView = DatePickerInputView()
+    
+    private let inProgressChip = InProgressChip()
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupLayout()
+        setupActions()
+        setupSwipeGesture()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        contentView.addSubview(containerView)
+        containerView.addSubview(stackView)
+        
+        stackView.addArrangedSubview(startDateLabel)
+        stackView.addArrangedSubview(startDatePickerInputView)
+        
+        endDateContainerView.addSubview(endDateLabel)
+        endDateContainerView.addSubview(endDatePickerInputView)
+        endDateContainerView.addSubview(inProgressChip)
+        stackView.addArrangedSubview(endDateContainerView)
+    }
+    
+    private func setupLayout() {
+        contentView.snp.makeConstraints {
+            $0.width.equalTo(UIScreen.main.bounds.width - 40)
+        }
+        
+        containerView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(20)
+        }
+        
+        endDateLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.top.equalToSuperview()
+        }
+        
+        endDatePickerInputView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.top.equalTo(endDateLabel.snp.bottom).offset(12)
+            $0.bottom.equalToSuperview()
+        }
+        
+        inProgressChip.snp.makeConstraints {
+            $0.trailing.equalToSuperview()
+            $0.centerY.equalTo(endDateLabel)
+        }
+    }
+    
+    private func setupActions() {
+        startDatePickerInputView.onDateSelected = { [weak self] date in
+            self?.onStartDateChanged?(date)
+        }
+        
+        endDatePickerInputView.onDateSelected = { [weak self] date in
+            self?.onEndDateChanged?(date)
+        }
+        
+        inProgressChip.onCheckChanged = { [weak self] isChecked in
+            self?.updateEndDateEnabled(!isChecked)
+            self?.onInProgressChanged?(isChecked)
+        }
+    }
+    
+    private func setupSwipeGesture() {
+        let swipeGesture = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipe))
+        swipeGesture.direction = .left
+        addGestureRecognizer(swipeGesture)
+    }
+    
+    private func updateEndDateEnabled(_ enabled: Bool) {
+        endDatePickerInputView.isUserInteractionEnabled = enabled
+        endDatePickerInputView.alpha = enabled ? 1.0 : 0.5
+    }
+    
+    @objc private func handleSwipe() {
+        showDeleteConfirmation()
+    }
+    
+    private func showDeleteConfirmation() {
+        let alert = UIAlertController(title: "삭제", message: "이 방사선 이력을 삭제하시겠습니까?", preferredStyle: .alert)
+        
+        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+            self?.onDelete?()
+        }
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+        alert.addAction(deleteAction)
+        alert.addAction(cancelAction)
+        
+        if let viewController = self.findViewController() {
+            viewController.present(alert, animated: true)
+        }
+    }
+    
+    func configure(startDate: Date?, endDate: Date?, isInProgress: Bool) {
+        startDatePickerInputView.selectedDate = startDate
+        endDatePickerInputView.selectedDate = endDate
+        inProgressChip.isChecked = isInProgress
+        updateEndDateEnabled(!isInProgress)
+    }
+    
+    private func findViewController() -> UIViewController? {
+        var responder: UIResponder? = self
+        while responder != nil {
+            responder = responder?.next
+            if let viewController = responder as? UIViewController {
+                return viewController
+            }
+        }
+        return nil
+    }
+}

--- a/ieum/Presentation/Main/MyPage/View/Components/SurgeryHistoryCell.swift
+++ b/ieum/Presentation/Main/MyPage/View/Components/SurgeryHistoryCell.swift
@@ -1,0 +1,145 @@
+import UIKit
+import SnapKit
+import Then
+
+final class SurgeryHistoryCell: UICollectionViewCell {
+    
+    static let identifier = "SurgeryHistoryCell"
+    
+    // MARK: - Properties
+    
+    var onDelete: (() -> Void)?
+    var onDateChanged: ((Date) -> Void)?
+    var onDescriptionChanged: ((String) -> Void)?
+    
+    // MARK: - UI Components
+    
+    private let containerView = UIView().then {
+        $0.backgroundColor = Colors.white
+        $0.layer.cornerRadius = 16
+        $0.layer.borderWidth = 1
+        $0.layer.borderColor = Colors.Slate.s200Border.cgColor
+    }
+    
+    private let stackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 12
+        $0.alignment = .fill
+        $0.distribution = .fill
+    }
+    
+    private let dateLabel = UILabel().then {
+        $0.text = "수술날짜"
+        $0.font = .ieum(UIFont.IeumFont.Heading.h5)
+        $0.textColor = Colors.Gray.g950
+    }
+    
+    private let datePickerInputView = DatePickerInputView()
+    
+    private let descriptionLabel = UILabel().then {
+        $0.text = "수술이름"
+        $0.font = .ieum(UIFont.IeumFont.Heading.h5)
+        $0.textColor = Colors.Gray.g950
+    }
+    
+    private let descriptionInputView = IeumInputView(maxCount: 20).then {
+        $0.textField.placeholder = "수술이름을 입력해주세요"
+        $0.setBorderColors(defaultColor: Colors.black, activeColor: Colors.Primary.green)
+    }
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupLayout()
+        setupActions()
+        setupSwipeGesture()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        contentView.addSubview(containerView)
+        containerView.addSubview(stackView)
+        
+        stackView.addArrangedSubview(dateLabel)
+        stackView.addArrangedSubview(datePickerInputView)
+        stackView.addArrangedSubview(descriptionLabel)
+        stackView.addArrangedSubview(descriptionInputView)
+    }
+    
+    private func setupLayout() {
+        contentView.snp.makeConstraints {
+            $0.width.equalTo(UIScreen.main.bounds.width - 40)
+        }
+        
+        containerView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(20)
+        }
+    }
+    
+    private func setupActions() {
+        datePickerInputView.onDateSelected = { [weak self] date in
+            self?.onDateChanged?(date)
+        }
+        
+        descriptionInputView.textField.addTarget(self, action: #selector(descriptionDidChange), for: .editingChanged)
+    }
+    
+    private func setupSwipeGesture() {
+        let swipeGesture = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipe))
+        swipeGesture.direction = .left
+        addGestureRecognizer(swipeGesture)
+    }
+    
+    @objc private func descriptionDidChange() {
+        let text = descriptionInputView.textField.text ?? ""
+        onDescriptionChanged?(text)
+    }
+    
+    @objc private func handleSwipe() {
+        showDeleteConfirmation()
+    }
+    
+    private func showDeleteConfirmation() {
+        let alert = UIAlertController(title: "삭제", message: "이 수술 이력을 삭제하시겠습니까?", preferredStyle: .alert)
+        
+        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+            self?.onDelete?()
+        }
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+        alert.addAction(deleteAction)
+        alert.addAction(cancelAction)
+        
+        if let viewController = self.findViewController() {
+            viewController.present(alert, animated: true)
+        }
+    }
+    
+    func configure(date: Date?, description: String) {
+        datePickerInputView.selectedDate = date
+        descriptionInputView.textField.text = description
+    }
+    
+    private func findViewController() -> UIViewController? {
+        var responder: UIResponder? = self
+        while responder != nil {
+            responder = responder?.next
+            if let viewController = responder as? UIViewController {
+                return viewController
+            }
+        }
+        return nil
+    }
+}

--- a/ieum/Presentation/Main/MyPage/View/MyPageMainViewController.swift
+++ b/ieum/Presentation/Main/MyPage/View/MyPageMainViewController.swift
@@ -52,8 +52,9 @@ final class MyPageMainViewController: UIViewController {
     
     private let tabStackView = UIStackView().then {
         $0.axis = .horizontal
-        $0.distribution = .fillEqually
-        $0.alignment = .fill
+        $0.distribution = .fill
+        $0.alignment = .center
+        $0.spacing = 24
     }
     
     private let profileTabButton = UIButton().then {
@@ -68,6 +69,11 @@ final class MyPageMainViewController: UIViewController {
         $0.titleLabel?.font = .ieum(UIFont.IeumFont.Text.bodyM)
         $0.setTitleColor(Colors.Slate.s900, for: .selected)
         $0.setTitleColor(Colors.Gray.g400, for: .normal)
+    }
+    
+    private let settingsButton = UIButton().then {
+        $0.setImage(UIImage(systemName: "gearshape"), for: .normal)
+        $0.tintColor = Colors.Gray.g950
     }
     
     private let indicatorView = UIView().then {
@@ -113,6 +119,7 @@ final class MyPageMainViewController: UIViewController {
     private func setupUI() {
         view.addSubview(headerView)
         headerView.addSubview(tabStackView)
+        headerView.addSubview(settingsButton)
         headerView.addSubview(indicatorView)
         
         tabStackView.addArrangedSubview(profileTabButton)
@@ -129,15 +136,22 @@ final class MyPageMainViewController: UIViewController {
         }
         
         tabStackView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.leading.equalToSuperview().offset(20)
+            $0.centerY.equalToSuperview()
         }
         
-        // Indicator width is half of screen width (since 2 tabs)
+        settingsButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(24)
+        }
+        
+        // Indicator will be positioned under selected tab button
         indicatorView.snp.makeConstraints {
             $0.bottom.equalToSuperview()
             $0.height.equalTo(2)
-            $0.width.equalToSuperview().multipliedBy(0.5)
-            $0.leading.equalToSuperview() // Initial leading
+            $0.leading.equalTo(profileTabButton)
+            $0.width.equalTo(profileTabButton)
         }
         
         containerView.snp.makeConstraints {
@@ -149,6 +163,7 @@ final class MyPageMainViewController: UIViewController {
     private func setupActions() {
         profileTabButton.addTarget(self, action: #selector(didTapProfileTab), for: .touchUpInside)
         postsTabButton.addTarget(self, action: #selector(didTapPostsTab), for: .touchUpInside)
+        settingsButton.addTarget(self, action: #selector(didTapSettings), for: .touchUpInside)
     }
     
     // MARK: - Tab Handling
@@ -161,6 +176,10 @@ final class MyPageMainViewController: UIViewController {
         currentTab = .posts
     }
     
+    @objc private func didTapSettings() {
+        coordinator?.showSettings()
+    }
+    
     private func updateTabUI() {
         let isProfile = currentTab == .profile
         profileTabButton.isSelected = isProfile
@@ -169,11 +188,14 @@ final class MyPageMainViewController: UIViewController {
         profileTabButton.titleLabel?.font = isProfile ? .ieum(UIFont.IeumFont.Heading.h4) : .ieum(UIFont.IeumFont.Text.bodyM)
         postsTabButton.titleLabel?.font = !isProfile ? .ieum(UIFont.IeumFont.Heading.h4) : .ieum(UIFont.IeumFont.Text.bodyM)
         
-        // Animate Indicator
-        let offset = isProfile ? 0 : view.frame.width / 2
+        // Animate Indicator to selected tab
+        let selectedButton = isProfile ? profileTabButton : postsTabButton
         
-        indicatorView.snp.updateConstraints {
-            $0.leading.equalToSuperview().offset(offset)
+        indicatorView.snp.remakeConstraints {
+            $0.bottom.equalToSuperview()
+            $0.height.equalTo(2)
+            $0.leading.equalTo(selectedButton)
+            $0.width.equalTo(selectedButton)
         }
         
         UIView.animate(withDuration: 0.3) {

--- a/ieum/Presentation/Main/MyPage/View/MyPostsViewController.swift
+++ b/ieum/Presentation/Main/MyPage/View/MyPostsViewController.swift
@@ -12,10 +12,6 @@ final class MyPostsViewController: UIViewController {
     
     // MARK: - UI Components
     
-    private let filterChipView = FilterChipView().then {
-        $0.backgroundColor = Colors.white
-    }
-    
     private let tableView = UITableView().then {
         $0.backgroundColor = Colors.white
         $0.separatorStyle = .none
@@ -57,21 +53,13 @@ final class MyPostsViewController: UIViewController {
     // MARK: - Setup
     
     private func setupUI() {
-        view.addSubview(filterChipView)
         view.addSubview(tableView)
         view.addSubview(loadingIndicator)
     }
     
     private func setupLayout() {
-        filterChipView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(16)
-            $0.leading.equalToSuperview().inset(20)
-            $0.trailing.equalToSuperview()
-            $0.height.equalTo(32)
-        }
-        
         tableView.snp.makeConstraints {
-            $0.top.equalTo(filterChipView.snp.bottom).offset(16)
+            $0.top.equalToSuperview().offset(16)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview()
         }
@@ -88,10 +76,6 @@ final class MyPostsViewController: UIViewController {
     }
     
     private func bindViewModel() {
-        filterChipView.onFilterSelected = { [weak self] filter in
-            self?.viewModel.didSelectFilter.send(filter)
-        }
-        
         viewModel.$posts
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/ieum/Presentation/Main/MyPage/View/MyPostsViewController.swift
+++ b/ieum/Presentation/Main/MyPage/View/MyPostsViewController.swift
@@ -24,6 +24,11 @@ final class MyPostsViewController: UIViewController {
         $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 20, right: 0)
     }
     
+    private let loadingIndicator = UIActivityIndicatorView(style: .medium).then {
+        $0.hidesWhenStopped = true
+        $0.color = Colors.Gray.g600
+    }
+    
     // MARK: - Initializer
     
     init(viewModel: MyPostsViewModel) {
@@ -54,6 +59,7 @@ final class MyPostsViewController: UIViewController {
     private func setupUI() {
         view.addSubview(filterChipView)
         view.addSubview(tableView)
+        view.addSubview(loadingIndicator)
     }
     
     private func setupLayout() {
@@ -68,6 +74,11 @@ final class MyPostsViewController: UIViewController {
             $0.top.equalTo(filterChipView.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview()
+        }
+        
+        loadingIndicator.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
     }
     
@@ -85,6 +96,17 @@ final class MyPostsViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.tableView.reloadData()
+            }
+            .store(in: &cancellables)
+        
+        viewModel.$isLoadingMore
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isLoadingMore in
+                if isLoadingMore {
+                    self?.loadingIndicator.startAnimating()
+                } else {
+                    self?.loadingIndicator.stopAnimating()
+                }
             }
             .store(in: &cancellables)
     }
@@ -120,5 +142,11 @@ extension MyPostsViewController: UITableViewDataSource {
 extension MyPostsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if indexPath.row == viewModel.posts.count - 1 {
+            viewModel.loadMore.send()
+        }
     }
 }

--- a/ieum/Presentation/Main/MyPage/View/MyProfileViewController.swift
+++ b/ieum/Presentation/Main/MyPage/View/MyProfileViewController.swift
@@ -104,13 +104,19 @@ final class MyProfileViewController: UIViewController {
         addInfoSection(title: "진단명", content: diagnosesText, isVisible: profile.diagnosesVisible, sectionType: .diagnosis)
         
         // Surgery
-        addInfoSection(title: "수술 이력", content: "수술 이력이 있다면 기록해 주세요", isVisible: profile.surgeryVisible, isPlaceholder: profile.surgery?.isEmpty ?? true, sectionType: .surgery)
+        let surgeryContent = formatSurgeryHistory(profile.surgery)
+        let surgeryIsPlaceholder = profile.surgery?.isEmpty ?? true
+        addInfoSection(title: "수술 이력", content: surgeryContent, isVisible: profile.surgeryVisible, isPlaceholder: surgeryIsPlaceholder, sectionType: .surgery)
         
         // Chemotherapy
-        addInfoSection(title: "항암 이력", content: "항암 이력이 있다면 기록해 주세요", isVisible: profile.chemotherapyVisible, isPlaceholder: profile.chemotherapy?.isEmpty ?? true, sectionType: .chemotherapy)
+        let chemotherapyContent = formatChemotherapyHistory(profile.chemotherapy)
+        let chemotherapyIsPlaceholder = profile.chemotherapy?.isEmpty ?? true
+        addInfoSection(title: "항암 이력", content: chemotherapyContent, isVisible: profile.chemotherapyVisible, isPlaceholder: chemotherapyIsPlaceholder, sectionType: .chemotherapy)
         
         // Radiation
-        addInfoSection(title: "방사선 이력", content: "방사선 이력이 있다면 기록해 주세요", isVisible: profile.radiationTherapyVisible, isPlaceholder: profile.radiationTherapy?.isEmpty ?? true, sectionType: .radiation)
+        let radiationContent = formatRadiationHistory(profile.radiationTherapy)
+        let radiationIsPlaceholder = profile.radiationTherapy?.isEmpty ?? true
+        addInfoSection(title: "방사선 이력", content: radiationContent, isVisible: profile.radiationTherapyVisible, isPlaceholder: radiationIsPlaceholder, sectionType: .radiation)
         
         // Age Group
         let ageGroupText = AgeGroup(rawValue: profile.ageGroup ?? "")?.title ?? ""
@@ -125,6 +131,40 @@ final class MyProfileViewController: UIViewController {
             regionText += "이용중 병원 : \(hospital)"
         }
         addInfoSection(title: "지역", content: regionText, isVisible: profile.residenceAreaVisible || profile.hospitalAreaVisible, sectionType: .residence)
+    }
+    
+    // MARK: - History Formatting
+    
+    private func formatSurgeryHistory(_ surgeries: [Surgery]?) -> String {
+        guard let surgeries = surgeries, !surgeries.isEmpty else {
+            return "수술 이력이 있다면 기록해 주세요"
+        }
+        
+        return surgeries.map { surgery in
+            "\(surgery.date): \(surgery.description)"
+        }.joined(separator: "\n")
+    }
+    
+    private func formatChemotherapyHistory(_ chemotherapies: [Chemotherapy]?) -> String {
+        guard let chemotherapies = chemotherapies, !chemotherapies.isEmpty else {
+            return "항암 이력이 있다면 기록해 주세요"
+        }
+        
+        return chemotherapies.map { chemo in
+            let endDateText = chemo.endDate ?? "진행중"
+            return "\(chemo.cycle)차 (\(chemo.startDate) ~ \(endDateText))"
+        }.joined(separator: "\n")
+    }
+    
+    private func formatRadiationHistory(_ radiations: [RadiationTherapy]?) -> String {
+        guard let radiations = radiations, !radiations.isEmpty else {
+            return "방사선 이력이 있다면 기록해 주세요"
+        }
+        
+        return radiations.map { radiation in
+            let endDateText = radiation.endDate ?? "진행중"
+            return "\(radiation.startDate) ~ \(endDateText)"
+        }.joined(separator: "\n")
     }
     
     private func addInfoSection(title: String, content: String, isVisible: Bool, isPlaceholder: Bool = false, sectionType: InfoSectionType) {
@@ -218,10 +258,9 @@ final class ProfileInfoSectionView: UIView {
         $0.textColor = Colors.Gray.g950
     }
     
-    private let visibilityBadge = UILabel().then {
-        $0.font = .ieum(UIFont.IeumFont.Text.bodyXSmall)
-        $0.textColor = Colors.Gray.g400
-        $0.text = "🔒 비공개"
+    private let visibilityBadge = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+        $0.tintColor = Colors.Gray.g400
     }
     
     private let arrowImageView = UIImageView().then {
@@ -285,6 +324,7 @@ final class ProfileInfoSectionView: UIView {
         visibilityBadge.snp.makeConstraints {
             $0.centerY.equalTo(titleLabel)
             $0.leading.equalTo(titleLabel.snp.trailing).offset(8)
+            $0.width.height.equalTo(16)
         }
         
         arrowImageView.snp.makeConstraints {
@@ -313,6 +353,13 @@ final class ProfileInfoSectionView: UIView {
     func configure(content: String, isVisible: Bool, isPlaceholder: Bool) {
         contentLabel.text = content
         contentLabel.textColor = isPlaceholder ? Colors.Gray.g400 : Colors.Gray.g800
-        visibilityBadge.isHidden = isVisible
+        
+        // 비공개면 닫힌 자물쇠, 공개면 숨김
+        if isVisible {
+            visibilityBadge.isHidden = true
+        } else {
+            visibilityBadge.isHidden = false
+            visibilityBadge.image = UIImage(systemName: "lock.fill")
+        }
     }
 }

--- a/ieum/Presentation/Main/MyPage/View/MyProfileViewController.swift
+++ b/ieum/Presentation/Main/MyPage/View/MyProfileViewController.swift
@@ -101,19 +101,20 @@ final class MyProfileViewController: UIViewController {
         let diagnosesText = profile.diagnoses.map {
             "\($0.diagnosisDisplayName) : \($0.cancerStage ?? 0)기"
         }.joined(separator: "  ")
-        addInfoSection(title: "진단명", content: diagnosesText, isVisible: profile.diagnosesVisible)
+        addInfoSection(title: "진단명", content: diagnosesText, isVisible: profile.diagnosesVisible, sectionType: .diagnosis)
         
         // Surgery
-        addInfoSection(title: "수술 이력", content: "수술 이력이 있다면 기록해 주세요", isVisible: profile.surgeryVisible, isPlaceholder: profile.surgery?.isEmpty ?? true)
+        addInfoSection(title: "수술 이력", content: "수술 이력이 있다면 기록해 주세요", isVisible: profile.surgeryVisible, isPlaceholder: profile.surgery?.isEmpty ?? true, sectionType: .surgery)
         
         // Chemotherapy
-        addInfoSection(title: "항암 이력", content: "항암 이력이 있다면 기록해 주세요", isVisible: profile.chemotherapyVisible, isPlaceholder: profile.chemotherapy?.isEmpty ?? true)
+        addInfoSection(title: "항암 이력", content: "항암 이력이 있다면 기록해 주세요", isVisible: profile.chemotherapyVisible, isPlaceholder: profile.chemotherapy?.isEmpty ?? true, sectionType: .chemotherapy)
         
         // Radiation
-        addInfoSection(title: "방사선 이력", content: "방사선 이력이 있다면 기록해 주세요", isVisible: profile.radiationTherapyVisible, isPlaceholder: profile.radiationTherapy?.isEmpty ?? true)
+        addInfoSection(title: "방사선 이력", content: "방사선 이력이 있다면 기록해 주세요", isVisible: profile.radiationTherapyVisible, isPlaceholder: profile.radiationTherapy?.isEmpty ?? true, sectionType: .radiation)
         
         // Age Group
-        addInfoSection(title: "연령대", content: profile.ageGroup ?? "", isVisible: profile.ageGroupVisible)
+        let ageGroupText = AgeGroup(rawValue: profile.ageGroup ?? "")?.title ?? ""
+        addInfoSection(title: "연령대", content: ageGroupText, isVisible: profile.ageGroupVisible, sectionType: .ageGroup)
         
         // Region
         var regionText = ""
@@ -123,12 +124,15 @@ final class MyProfileViewController: UIViewController {
         if let hospital = profile.hospitalArea {
             regionText += "이용중 병원 : \(hospital)"
         }
-        addInfoSection(title: "지역", content: regionText, isVisible: profile.residenceAreaVisible || profile.hospitalAreaVisible)
+        addInfoSection(title: "지역", content: regionText, isVisible: profile.residenceAreaVisible || profile.hospitalAreaVisible, sectionType: .residence)
     }
     
-    private func addInfoSection(title: String, content: String, isVisible: Bool, isPlaceholder: Bool = false) {
+    private func addInfoSection(title: String, content: String, isVisible: Bool, isPlaceholder: Bool = false, sectionType: InfoSectionType) {
         let sectionView = ProfileInfoSectionView(title: title)
         sectionView.configure(content: content, isVisible: isVisible, isPlaceholder: isPlaceholder)
+        sectionView.onInfoSectionTapped = { [weak self] in
+            self?.viewModel.didTapInfoSection.send(sectionType)
+        }
         infoStackView.addArrangedSubview(sectionView)
     }
 }
@@ -207,8 +211,10 @@ final class ProfileHeaderView: UIView {
 
 final class ProfileInfoSectionView: UIView {
     
+    var onInfoSectionTapped: (() -> Void)?
+    
     private let titleLabel = UILabel().then {
-        $0.font = .ieum(UIFont.IeumFont.Text.bodyM) // Bold?
+        $0.font = .ieum(UIFont.IeumFont.Text.bodyM)
         $0.textColor = Colors.Gray.g950
     }
     
@@ -244,6 +250,7 @@ final class ProfileInfoSectionView: UIView {
         titleLabel.text = title
         setupUI()
         setupLayout()
+        setupTapGesture()
     }
     
     required init?(coder: NSCoder) {
@@ -257,6 +264,16 @@ final class ProfileInfoSectionView: UIView {
         addSubview(contentContainer)
         contentContainer.addSubview(contentLabel)
         addSubview(dividerView)
+    }
+    
+    private func setupTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        addGestureRecognizer(tapGesture)
+        isUserInteractionEnabled = true
+    }
+    
+    @objc private func handleTap() {
+        onInfoSectionTapped?()
     }
     
     private func setupLayout() {

--- a/ieum/Presentation/Main/MyPage/View/PrivacyPolicyViewController.swift
+++ b/ieum/Presentation/Main/MyPage/View/PrivacyPolicyViewController.swift
@@ -1,0 +1,107 @@
+import UIKit
+import WebKit
+import SnapKit
+import Then
+
+final class PrivacyPolicyViewController: UIViewController {
+    
+    // MARK: - Constants
+    
+    private let privacyPolicyURL = "https://southern-dash-bc7.notion.site/2f7a0853c74280b7b6a1d7a0172cbdac"
+    
+    // MARK: - UI Components
+    
+    private let webView = WKWebView().then {
+        $0.backgroundColor = Colors.white
+    }
+    
+    private let loadingIndicator = UIActivityIndicatorView(style: .medium).then {
+        $0.hidesWhenStopped = true
+        $0.color = Colors.Gray.g600
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = Colors.white
+        setupNavigationBar()
+        setupUI()
+        setupLayout()
+        loadPrivacyPolicy()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+    
+    // MARK: - Setup
+    
+    private func setupNavigationBar() {
+        title = "개인정보 처리방침"
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = Colors.white
+        appearance.titleTextAttributes = [
+            .foregroundColor: Colors.Gray.g950,
+            .font: UIFont.ieum(UIFont.IeumFont.Heading.h4)
+        ]
+        
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        
+        let backButton = UIBarButtonItem(
+            image: UIImage(systemName: "chevron.left"),
+            style: .plain,
+            target: self,
+            action: #selector(didTapBack)
+        )
+        backButton.tintColor = Colors.Gray.g950
+        navigationItem.leftBarButtonItem = backButton
+    }
+    
+    private func setupUI() {
+        view.addSubview(webView)
+        view.addSubview(loadingIndicator)
+        
+        webView.navigationDelegate = self
+    }
+    
+    private func setupLayout() {
+        webView.snp.makeConstraints {
+            $0.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        loadingIndicator.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func didTapBack() {
+        navigationController?.popViewController(animated: true)
+    }
+    
+    private func loadPrivacyPolicy() {
+        guard let url = URL(string: privacyPolicyURL) else { return }
+        let request = URLRequest(url: url)
+        loadingIndicator.startAnimating()
+        webView.load(request)
+    }
+}
+
+// MARK: - WKNavigationDelegate
+
+extension PrivacyPolicyViewController: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        loadingIndicator.stopAnimating()
+    }
+    
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        loadingIndicator.stopAnimating()
+        print("WebView loading failed: \(error.localizedDescription)")
+    }
+}

--- a/ieum/Presentation/Main/MyPage/View/RadiationHistoryViewController.swift
+++ b/ieum/Presentation/Main/MyPage/View/RadiationHistoryViewController.swift
@@ -1,0 +1,226 @@
+import UIKit
+import SnapKit
+import Then
+import Combine
+
+final class RadiationHistoryViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    private let viewModel = RadiationHistoryViewModel()
+    private var cancellables = Set<AnyCancellable>()
+    
+    var onComplete: (([RadiationTherapyRequest], Bool) -> Void)?
+    private var initialRadiations: [RadiationTherapy]?
+    
+    // MARK: - UI Components
+    
+    private let titleLabel = UILabel().then {
+        $0.text = "받으신 방사선 치료 내용을\n입력해주세요"
+        $0.font = .ieum(UIFont.IeumFont.Heading.h1)
+        $0.textColor = Colors.Gray.g950
+        $0.numberOfLines = 0
+    }
+    
+    private let collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 20
+        layout.minimumInteritemSpacing = 0
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+        layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = Colors.Slate.s50
+        collectionView.showsVerticalScrollIndicator = false
+        return collectionView
+    }()
+    
+    private let addButton = IeumButton(title: "방사선치료 이력 추가 +").then {
+        $0.setStyle(backgroundColor: Colors.Gray.g200, titleColor: Colors.Gray.g600, for: .normal)
+    }
+    
+    private let privacyChip = PrivacyChip()
+    
+    private let completeButton = IeumButton(title: "완료").then {
+        $0.setStyle(backgroundColor: Colors.Lime.l100, titleColor: Colors.Gray.g950, for: .normal)
+        $0.setStyle(backgroundColor: Colors.Gray.g200, titleColor: Colors.Gray.g400, for: .disabled)
+        $0.layer.borderWidth = 1.5
+        $0.layer.borderColor = Colors.Lime.l200.cgColor
+        $0.isEnabled = false
+    }
+    
+    // MARK: - Initializer
+    
+    convenience init(initialRadiations: [RadiationTherapy]?, onComplete: @escaping ([RadiationTherapyRequest], Bool) -> Void) {
+        self.init()
+        self.initialRadiations = initialRadiations
+        self.onComplete = onComplete
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = Colors.Slate.s50
+        
+        setupUI()
+        setupLayout()
+        setupCollectionView()
+        bindViewModel()
+        
+        if let initialRadiations = initialRadiations {
+            viewModel.setupInitialData(initialRadiations)
+        } else {
+            viewModel.didTapAddHistory.send()
+        }
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupNavigationBar()
+    }
+    
+    // MARK: - Setup
+    
+    private func setupNavigationBar() {
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = Colors.Slate.s50
+        appearance.shadowColor = .clear
+        
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.tintColor = Colors.Gray.g950
+        
+        let backItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        navigationController?.navigationBar.topItem?.backBarButtonItem = backItem
+    }
+    
+    private func setupUI() {
+        view.addSubview(titleLabel)
+        view.addSubview(collectionView)
+        view.addSubview(addButton)
+        view.addSubview(privacyChip)
+        view.addSubview(completeButton)
+    }
+    
+    private func setupLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+            $0.leading.equalToSuperview().offset(20)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+        
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(24)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(addButton.snp.top).offset(-16)
+        }
+        
+        addButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalTo(privacyChip.snp.top).offset(-16)
+            $0.height.equalTo(56)
+        }
+        
+        privacyChip.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(completeButton.snp.top).offset(-16)
+        }
+        
+        completeButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.height.equalTo(72)
+        }
+    }
+    
+    private func setupCollectionView() {
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.register(RadiationHistoryCell.self, forCellWithReuseIdentifier: RadiationHistoryCell.identifier)
+    }
+    
+    private func bindViewModel() {
+        addButton.addTarget(self, action: #selector(didTapAdd), for: .touchUpInside)
+        completeButton.addTarget(self, action: #selector(didTapComplete), for: .touchUpInside)
+        
+        privacyChip.onCheckChanged = { [weak self] isChecked in
+            self?.viewModel.didChangePrivacy.send(isChecked)
+        }
+        
+        viewModel.$historyItems
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.collectionView.reloadData()
+            }
+            .store(in: &cancellables)
+        
+        viewModel.$isCompleteButtonEnabled
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.isEnabled, on: completeButton)
+            .store(in: &cancellables)
+        
+        viewModel.navigateToComplete
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] radiations, isPrivate in
+                self?.onComplete?(radiations, isPrivate)
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func didTapAdd() {
+        viewModel.didTapAddHistory.send()
+    }
+    
+    @objc private func didTapComplete() {
+        viewModel.didTapComplete.send()
+    }
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension RadiationHistoryViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return viewModel.historyItems.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RadiationHistoryCell.identifier, for: indexPath) as? RadiationHistoryCell else {
+            return UICollectionViewCell()
+        }
+        
+        let item = viewModel.historyItems[indexPath.item]
+        cell.configure(startDate: item.startDate, endDate: item.endDate, isInProgress: item.isInProgress)
+        
+        cell.onDelete = { [weak self] in
+            self?.viewModel.didTapDeleteHistory.send(indexPath.item)
+        }
+        
+        cell.onStartDateChanged = { [weak self] date in
+            self?.viewModel.didUpdateStartDate.send((index: indexPath.item, date: date))
+        }
+        
+        cell.onEndDateChanged = { [weak self] date in
+            self?.viewModel.didUpdateEndDate.send((index: indexPath.item, date: date))
+        }
+        
+        cell.onInProgressChanged = { [weak self] isInProgress in
+            self?.viewModel.didToggleInProgress.send((index: indexPath.item, isInProgress: isInProgress))
+        }
+        
+        return cell
+    }
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension RadiationHistoryViewController: UICollectionViewDelegate {
+    // Delegate methods can be added here if needed
+}
+

--- a/ieum/Presentation/Main/MyPage/View/SettingsViewController.swift
+++ b/ieum/Presentation/Main/MyPage/View/SettingsViewController.swift
@@ -1,0 +1,227 @@
+import UIKit
+import SnapKit
+import Then
+
+protocol SettingsViewControllerDelegate: AnyObject {
+    func didTapPrivacyPolicy()
+    func didTapDeleteAccount()
+    func didTapLogout()
+}
+
+final class SettingsViewController: UIViewController {
+    
+    // MARK: - Types
+    
+    enum SettingsSection: Int, CaseIterable {
+        case info       // 정보 섹션 (개인정보 처리방침)
+        case account    // 계정 섹션 (회원탈퇴, 로그아웃)
+    }
+    
+    enum SettingsItem {
+        case privacyPolicy    // 개인정보 처리방침
+        case deleteAccount    // 회원탈퇴
+        case logout           // 로그아웃
+        
+        var title: String {
+            switch self {
+            case .privacyPolicy: return "개인정보 처리방침"
+            case .deleteAccount: return "회원탈퇴"
+            case .logout: return "로그아웃"
+            }
+        }
+        
+        var textColor: UIColor {
+            switch self {
+            case .deleteAccount, .logout: return UIColor.systemRed
+            default: return Colors.Gray.g950
+            }
+        }
+    }
+    
+    // MARK: - Properties
+    
+    weak var delegate: SettingsViewControllerDelegate?
+    
+    private let infoItems: [SettingsItem] = [.privacyPolicy]
+    private let accountItems: [SettingsItem] = [.deleteAccount, .logout]
+    
+    // MARK: - UI Components
+    
+    private let tableView = UITableView(frame: .zero, style: .insetGrouped).then {
+        $0.backgroundColor = Colors.Slate.s50
+        $0.separatorStyle = .singleLine
+        $0.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = Colors.Slate.s50
+        setupNavigationBar()
+        setupUI()
+        setupLayout()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+    
+    // MARK: - Setup
+    
+    private func setupNavigationBar() {
+        title = "설정"
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = Colors.white
+        appearance.titleTextAttributes = [
+            .foregroundColor: Colors.Gray.g950,
+            .font: UIFont.ieum(UIFont.IeumFont.Heading.h4)
+        ]
+        
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        
+        let backButton = UIBarButtonItem(
+            image: UIImage(systemName: "chevron.left"),
+            style: .plain,
+            target: self,
+            action: #selector(didTapBack)
+        )
+        backButton.tintColor = Colors.Gray.g950
+        navigationItem.leftBarButtonItem = backButton
+    }
+    
+    private func setupUI() {
+        view.addSubview(tableView)
+        
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "SettingsCell")
+    }
+    
+    private func setupLayout() {
+        tableView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func didTapBack() {
+        navigationController?.popViewController(animated: true)
+    }
+    
+    private func handleItemSelection(_ item: SettingsItem) {
+        switch item {
+        case .privacyPolicy:
+            delegate?.didTapPrivacyPolicy()
+        case .deleteAccount:
+            showDeleteAccountConfirmation()
+        case .logout:
+            showLogoutConfirmation()
+        }
+    }
+    
+    private func showDeleteAccountConfirmation() {
+        let alert = UIAlertController(
+            title: "회원탈퇴",
+            message: "정말 탈퇴하시겠습니까?\n모든 게시물, 댓글, 이미지가 삭제됩니다.",
+            preferredStyle: .alert
+        )
+        
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        alert.addAction(UIAlertAction(title: "탈퇴하기", style: .destructive) { [weak self] _ in
+            self?.delegate?.didTapDeleteAccount()
+        })
+        
+        present(alert, animated: true)
+    }
+    
+    private func showLogoutConfirmation() {
+        let alert = UIAlertController(
+            title: "로그아웃",
+            message: "로그아웃 하시겠습니까?",
+            preferredStyle: .alert
+        )
+        
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        alert.addAction(UIAlertAction(title: "로그아웃", style: .destructive) { [weak self] _ in
+            self?.delegate?.didTapLogout()
+        })
+        
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension SettingsViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return SettingsSection.allCases.count
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard let sectionType = SettingsSection(rawValue: section) else { return 0 }
+        switch sectionType {
+        case .info:
+            return infoItems.count
+        case .account:
+            return accountItems.count
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "SettingsCell", for: indexPath)
+        let item = getItem(at: indexPath)
+        
+        var content = cell.defaultContentConfiguration()
+        content.text = item.title
+        content.textProperties.color = item.textColor
+        content.textProperties.font = .ieum(UIFont.IeumFont.Text.bodyM)
+        
+        cell.contentConfiguration = content
+        cell.backgroundColor = Colors.white
+        cell.selectionStyle = .none
+        cell.accessoryType = item.title == "개인정보 처리방침" ? .disclosureIndicator : .none
+        
+        return cell
+    }
+    
+    private func getItem(at indexPath: IndexPath) -> SettingsItem {
+        guard let sectionType = SettingsSection(rawValue: indexPath.section) else {
+            return .privacyPolicy
+        }
+        switch sectionType {
+        case .info:
+            return infoItems[indexPath.row]
+        case .account:
+            return accountItems[indexPath.row]
+        }
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension SettingsViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let item = getItem(at: indexPath)
+        handleItemSelection(item)
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 56
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        // 섹션 간 간격을 위한 빈 헤더
+        return nil
+    }
+    
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return section == 0 ? 0 : 20
+    }
+}

--- a/ieum/Presentation/Main/MyPage/View/SurgeryHistoryViewController.swift
+++ b/ieum/Presentation/Main/MyPage/View/SurgeryHistoryViewController.swift
@@ -1,0 +1,222 @@
+import UIKit
+import SnapKit
+import Then
+import Combine
+
+final class SurgeryHistoryViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    private let viewModel = SurgeryHistoryViewModel()
+    private var cancellables = Set<AnyCancellable>()
+    
+    var onComplete: (([SurgeryRequest], Bool) -> Void)?
+    private var initialSurgeries: [Surgery]?
+    
+    // MARK: - UI Components
+    
+    private let titleLabel = UILabel().then {
+        $0.text = "수술하신 내용을\n알려주세요"
+        $0.font = .ieum(UIFont.IeumFont.Heading.h1)
+        $0.textColor = Colors.Gray.g950
+        $0.numberOfLines = 0
+    }
+    
+    private let collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 20
+        layout.minimumInteritemSpacing = 0
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+        layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = Colors.Slate.s50
+        collectionView.showsVerticalScrollIndicator = false
+        return collectionView
+    }()
+    
+    private let addButton = IeumButton(title: "수술이력 추가 +").then {
+        $0.setStyle(backgroundColor: Colors.Gray.g200, titleColor: Colors.Gray.g600, for: .normal)
+    }
+    
+    private let privacyChip = PrivacyChip()
+    
+    private let completeButton = IeumButton(title: "완료").then {
+        $0.setStyle(backgroundColor: Colors.Lime.l100, titleColor: Colors.Gray.g950, for: .normal)
+        $0.setStyle(backgroundColor: Colors.Gray.g200, titleColor: Colors.Gray.g400, for: .disabled)
+        $0.layer.borderWidth = 1.5
+        $0.layer.borderColor = Colors.Lime.l200.cgColor
+        $0.isEnabled = false
+    }
+    
+    // MARK: - Initializer
+    
+    convenience init(initialSurgeries: [Surgery]?, onComplete: @escaping ([SurgeryRequest], Bool) -> Void) {
+        self.init()
+        self.initialSurgeries = initialSurgeries
+        self.onComplete = onComplete
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = Colors.Slate.s50
+        
+        setupUI()
+        setupLayout()
+        setupCollectionView()
+        bindViewModel()
+        
+        if let initialSurgeries = initialSurgeries {
+            viewModel.setupInitialData(initialSurgeries)
+        } else {
+            viewModel.didTapAddHistory.send()
+        }
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupNavigationBar()
+    }
+    
+    // MARK: - Setup
+    
+    private func setupNavigationBar() {
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = Colors.Slate.s50
+        appearance.shadowColor = .clear
+        
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.tintColor = Colors.Gray.g950
+        
+        let backItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        navigationController?.navigationBar.topItem?.backBarButtonItem = backItem
+    }
+    
+    private func setupUI() {
+        view.addSubview(titleLabel)
+        view.addSubview(collectionView)
+        view.addSubview(addButton)
+        view.addSubview(privacyChip)
+        view.addSubview(completeButton)
+    }
+    
+    private func setupLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+            $0.leading.equalToSuperview().offset(20)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+        
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(24)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(addButton.snp.top).offset(-16)
+        }
+        
+        addButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalTo(privacyChip.snp.top).offset(-16)
+            $0.height.equalTo(56)
+        }
+        
+        privacyChip.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(completeButton.snp.top).offset(-16)
+        }
+        
+        completeButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.height.equalTo(72)
+        }
+    }
+    
+    private func setupCollectionView() {
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.register(SurgeryHistoryCell.self, forCellWithReuseIdentifier: SurgeryHistoryCell.identifier)
+    }
+    
+    private func bindViewModel() {
+        addButton.addTarget(self, action: #selector(didTapAdd), for: .touchUpInside)
+        completeButton.addTarget(self, action: #selector(didTapComplete), for: .touchUpInside)
+        
+        privacyChip.onCheckChanged = { [weak self] isChecked in
+            self?.viewModel.didChangePrivacy.send(isChecked)
+        }
+        
+        viewModel.$historyItems
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.collectionView.reloadData()
+            }
+            .store(in: &cancellables)
+        
+        viewModel.$isCompleteButtonEnabled
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.isEnabled, on: completeButton)
+            .store(in: &cancellables)
+        
+        viewModel.navigateToComplete
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] surgeries, isPrivate in
+                self?.onComplete?(surgeries, isPrivate)
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func didTapAdd() {
+        viewModel.didTapAddHistory.send()
+    }
+    
+    @objc private func didTapComplete() {
+        viewModel.didTapComplete.send()
+    }
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension SurgeryHistoryViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return viewModel.historyItems.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SurgeryHistoryCell.identifier, for: indexPath) as? SurgeryHistoryCell else {
+            return UICollectionViewCell()
+        }
+        
+        let item = viewModel.historyItems[indexPath.item]
+        cell.configure(date: item.date, description: item.description)
+        
+        cell.onDelete = { [weak self] in
+            self?.viewModel.didTapDeleteHistory.send(indexPath.item)
+        }
+        
+        cell.onDateChanged = { [weak self] date in
+            self?.viewModel.didUpdateDate.send((index: indexPath.item, date: date))
+        }
+        
+        cell.onDescriptionChanged = { [weak self] description in
+            self?.viewModel.didUpdateDescription.send((index: indexPath.item, description: description))
+        }
+        
+        return cell
+    }
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension SurgeryHistoryViewController: UICollectionViewDelegate {
+    // Delegate methods can be added here if needed
+}
+

--- a/ieum/Presentation/Main/MyPage/ViewModel/ChemotherapyHistoryViewModel.swift
+++ b/ieum/Presentation/Main/MyPage/ViewModel/ChemotherapyHistoryViewModel.swift
@@ -1,0 +1,189 @@
+import Foundation
+import Combine
+import OSLog
+
+final class ChemotherapyHistoryViewModel: ObservableObject {
+    
+    // MARK: - Inputs
+    
+    let didTapAddHistory = PassthroughSubject<Void, Never>()
+    let didTapDeleteHistory = PassthroughSubject<Int, Never>()
+    let didUpdateCycle = PassthroughSubject<(index: Int, cycle: Int), Never>()
+    let didUpdateStartDate = PassthroughSubject<(index: Int, date: Date), Never>()
+    let didUpdateEndDate = PassthroughSubject<(index: Int, date: Date), Never>()
+    let didToggleInProgress = PassthroughSubject<(index: Int, isInProgress: Bool), Never>()
+    let didChangePrivacy = PassthroughSubject<Bool, Never>()
+    let didTapComplete = PassthroughSubject<Void, Never>()
+    
+    // MARK: - Outputs
+    
+    @Published private(set) var historyItems: [ChemotherapyHistoryItem] = []
+    @Published private(set) var isPrivate: Bool = false
+    @Published private(set) var isCompleteButtonEnabled = false
+    
+    // MARK: - Navigation Events
+    
+    let navigateToComplete = PassthroughSubject<([ChemotherapyRequest], Bool), Never>()
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    init() {
+        bindInputs()
+    }
+    
+    private func bindInputs() {
+        didTapAddHistory
+            .sink { [weak self] in
+                self?.addHistoryItem()
+            }
+            .store(in: &cancellables)
+        
+        didTapDeleteHistory
+            .sink { [weak self] index in
+                self?.deleteHistoryItem(at: index)
+            }
+            .store(in: &cancellables)
+        
+        didUpdateCycle
+            .sink { [weak self] index, cycle in
+                self?.updateCycle(at: index, cycle: cycle)
+            }
+            .store(in: &cancellables)
+        
+        didUpdateStartDate
+            .sink { [weak self] index, date in
+                self?.updateStartDate(at: index, date: date)
+            }
+            .store(in: &cancellables)
+        
+        didUpdateEndDate
+            .sink { [weak self] index, date in
+                self?.updateEndDate(at: index, date: date)
+            }
+            .store(in: &cancellables)
+        
+        didToggleInProgress
+            .sink { [weak self] index, isInProgress in
+                self?.toggleInProgress(at: index, isInProgress: isInProgress)
+            }
+            .store(in: &cancellables)
+        
+        didChangePrivacy
+            .sink { [weak self] isPrivate in
+                self?.isPrivate = isPrivate
+            }
+            .store(in: &cancellables)
+        
+        didTapComplete
+            .sink { [weak self] in
+                self?.complete()
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Methods
+    
+    func setupInitialData(_ chemotherapies: [Chemotherapy]?) {
+        guard let chemotherapies = chemotherapies, !chemotherapies.isEmpty else {
+            addHistoryItem()
+            return
+        }
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        
+        historyItems = chemotherapies.enumerated().map { index, chemo in
+            let startDate = formatter.date(from: chemo.startDate)
+            let endDate = chemo.endDate.flatMap { formatter.date(from: $0) }
+            let isInProgress = endDate == nil
+            
+            return ChemotherapyHistoryItem(
+                cycle: chemo.cycle,
+                startDate: startDate,
+                endDate: endDate,
+                isInProgress: isInProgress
+            )
+        }
+        
+        updateCompleteButtonState()
+    }
+    
+    private func addHistoryItem() {
+        let nextCycle = historyItems.count + 1
+        historyItems.append(ChemotherapyHistoryItem(cycle: nextCycle, startDate: nil, endDate: nil, isInProgress: false))
+        updateCompleteButtonState()
+    }
+    
+    private func deleteHistoryItem(at index: Int) {
+        guard index < historyItems.count else { return }
+        historyItems.remove(at: index)
+        updateCycleNumbers()
+        updateCompleteButtonState()
+    }
+    
+    private func updateCycleNumbers() {
+        for index in historyItems.indices {
+            historyItems[index].cycle = index + 1
+        }
+    }
+    
+    private func updateCycle(at index: Int, cycle: Int) {
+        guard index < historyItems.count else { return }
+        historyItems[index].cycle = cycle
+        updateCompleteButtonState()
+    }
+    
+    private func updateStartDate(at index: Int, date: Date) {
+        guard index < historyItems.count else { return }
+        historyItems[index].startDate = date
+        updateCompleteButtonState()
+    }
+    
+    private func updateEndDate(at index: Int, date: Date) {
+        guard index < historyItems.count else { return }
+        historyItems[index].endDate = date
+        updateCompleteButtonState()
+    }
+    
+    private func toggleInProgress(at index: Int, isInProgress: Bool) {
+        guard index < historyItems.count else { return }
+        historyItems[index].isInProgress = isInProgress
+        if isInProgress {
+            historyItems[index].endDate = nil
+        }
+        updateCompleteButtonState()
+    }
+    
+    private func updateCompleteButtonState() {
+        let hasValidItems = historyItems.contains { item in
+            item.startDate != nil && (item.isInProgress || item.endDate != nil)
+        }
+        isCompleteButtonEnabled = hasValidItems
+    }
+    
+    private func complete() {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        
+        let chemoRequests = historyItems.compactMap { item -> ChemotherapyRequest? in
+            guard let startDate = item.startDate else { return nil }
+            
+            let endDateString: String?
+            if item.isInProgress {
+                endDateString = nil
+            } else if let endDate = item.endDate {
+                endDateString = formatter.string(from: endDate)
+            } else {
+                return nil
+            }
+            
+            return ChemotherapyRequest(
+                startDate: formatter.string(from: startDate),
+                endDate: endDateString,
+                cycle: item.cycle
+            )
+        }
+        
+        navigateToComplete.send((chemoRequests, isPrivate))
+    }
+}

--- a/ieum/Presentation/Main/MyPage/ViewModel/MyPageViewModel.swift
+++ b/ieum/Presentation/Main/MyPage/ViewModel/MyPageViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import OSLog
 
 final class MyPageViewModel: ObservableObject {
     
@@ -12,11 +13,13 @@ final class MyPageViewModel: ObservableObject {
     @Published private(set) var userProfile: UserProfile?
     @Published private(set) var isLoading = false
     
+    private let authRepository: AuthRepository
     private var cancellables = Set<AnyCancellable>()
     
     // MARK: - Initializer
     
-    init() {
+    init(authRepository: AuthRepository = AuthRepositoryImpl()) {
+        self.authRepository = authRepository
         bindInputs()
     }
     
@@ -33,40 +36,108 @@ final class MyPageViewModel: ObservableObject {
     private func fetchUserProfile() {
         isLoading = true
         
-        // Mock Data
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            let mockProfile = UserProfile(
-                id: 1,
-                oauthProvider: "kakao",
-                email: "user@example.com",
-                userType: "patient",
-                sex: "male",
-                nickname: "user_me",
-                diagnoses: [
-                    UserDiagnosis(diagnosis: "rectal_cancer", cancerStage: 4),
-                    UserDiagnosis(diagnosis: "colon_cancer", cancerStage: 4)
-                ],
-                surgery: [],
-                chemotherapy: [],
-                radiationTherapy: [],
-                ageGroup: "30s",
-                residenceArea: "서울특별시 강남구",
-                hospitalArea: "서울특별시 강남구",
-                sexVisible: false,
-                diagnosesVisible: false,
-                surgeryVisible: false,
-                chemotherapyVisible: false,
-                radiationTherapyVisible: false,
-                ageGroupVisible: false,
-                residenceAreaVisible: false,
-                hospitalAreaVisible: false,
-                registeredAt: 1754972400,
-                updatedAt: 1754972400
+        authRepository.getProfile()
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    self?.isLoading = false
+                    if case .failure(let error) = completion {
+                        Logger.network.error("프로필 조회 실패: \(error.localizedDescription)")
+                    }
+                },
+                receiveValue: { [weak self] profile in
+                    self?.userProfile = profile
+                    self?.isLoading = false
+                }
             )
-            
-            self?.userProfile = mockProfile
-            self?.isLoading = false
-        }
+            .store(in: &cancellables)
+    }
+    
+    func updateProfile(_ request: UpdateProfileRequest) -> AnyPublisher<UserProfile, Error> {
+        isLoading = true
+        
+        return authRepository.updateProfile(request)
+            .receive(on: DispatchQueue.main)
+            .handleEvents(
+                receiveOutput: { [weak self] profile in
+                    self?.userProfile = profile
+                    self?.isLoading = false
+                },
+                receiveCompletion: { [weak self] completion in
+                    self?.isLoading = false
+                    if case .failure(let error) = completion {
+                        Logger.network.error("프로필 수정 실패: \(error.localizedDescription)")
+                    }
+                }
+            )
+            .eraseToAnyPublisher()
+    }
+    
+    func createUpdateRequest(
+        from profile: UserProfile,
+        updatingDiagnoses: [DiagnosisRequest]? = nil,
+        updatingAgeGroup: String? = nil,
+        updatingResidenceArea: String? = nil,
+        updatingHospitalArea: String? = nil,
+        updatingSurgery: [SurgeryRequest]? = nil,
+        updatingChemotherapy: [ChemotherapyRequest]? = nil,
+        updatingRadiationTherapy: [RadiationTherapyRequest]? = nil
+    ) -> UpdateProfileRequest {
+        let diagnoses: [DiagnosisRequest]? = updatingDiagnoses ?? {
+            guard !profile.diagnoses.isEmpty else { return nil }
+            return profile.diagnoses.compactMap { userDiagnosis -> DiagnosisRequest? in
+                if userDiagnosis.diagnosis == "breast_cancer" {
+                    return nil
+                }
+                
+                var diagnosisType: DiagnosisType
+                switch userDiagnosis.diagnosis {
+                case "rectal_cancer":
+                    diagnosisType = .rectalCancer
+                case "colon_cancer":
+                    diagnosisType = .colonCancer
+                case "liver_transplant":
+                    diagnosisType = .liverTransplant
+                default:
+                    diagnosisType = .others
+                }
+                
+                return DiagnosisRequest(diagnosis: diagnosisType, cancerStage: userDiagnosis.cancerStage)
+            }
+        }()
+        
+        let surgery: [SurgeryRequest]? = updatingSurgery ?? {
+            guard let surgeries = profile.surgery, !surgeries.isEmpty else { return nil }
+            return surgeries.map { SurgeryRequest(date: $0.date, description: $0.description) }
+        }()
+        
+        let chemotherapy: [ChemotherapyRequest]? = updatingChemotherapy ?? {
+            guard let chemos = profile.chemotherapy, !chemos.isEmpty else { return nil }
+            return chemos.map { ChemotherapyRequest(startDate: $0.startDate, endDate: $0.endDate, cycle: $0.cycle) }
+        }()
+        
+        let radiationTherapy: [RadiationTherapyRequest]? = updatingRadiationTherapy ?? {
+            guard let radiations = profile.radiationTherapy, !radiations.isEmpty else { return nil }
+            return radiations.map { RadiationTherapyRequest(startDate: $0.startDate, endDate: $0.endDate) }
+        }()
+        
+        return UpdateProfileRequest(
+            diagnoses: diagnoses,
+            surgery: surgery,
+            chemotherapy: chemotherapy,
+            radiationTherapy: radiationTherapy,
+            ageGroup: updatingAgeGroup ?? profile.ageGroup,
+            residenceArea: updatingResidenceArea ?? profile.residenceArea,
+            hospitalArea: updatingHospitalArea ?? profile.hospitalArea,
+            sexVisible: profile.sexVisible,
+            diagnosesVisible: profile.diagnosesVisible,
+            surgeryVisible: profile.surgeryVisible,
+            chemotherapyVisible: profile.chemotherapyVisible,
+            radiationTherapyVisible: profile.radiationTherapyVisible,
+            ageGroupVisible: profile.ageGroupVisible,
+            residenceAreaVisible: profile.residenceAreaVisible,
+            hospitalAreaVisible: profile.hospitalAreaVisible
+        )
     }
 }
 

--- a/ieum/Presentation/Main/MyPage/ViewModel/MyPostsViewModel.swift
+++ b/ieum/Presentation/Main/MyPage/ViewModel/MyPostsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import OSLog
 
 final class MyPostsViewModel: ObservableObject {
     
@@ -11,6 +12,7 @@ final class MyPostsViewModel: ObservableObject {
     // MARK: - Outputs
     @Published private(set) var posts: [Post] = []
     @Published private(set) var isLoading = false
+    @Published private(set) var isLoadingMore = false
     @Published private(set) var currentFilter: String = "전체"
     @Published private(set) var error: Error?
     
@@ -18,8 +20,8 @@ final class MyPostsViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     
     private var currentPage = 1
-    private let pageSize = 10
-    private var isLastPage = false
+    private let pageSize = 20
+    private var hasMorePages = true
     
     // MARK: - Initializer
     
@@ -44,7 +46,7 @@ final class MyPostsViewModel: ObservableObject {
             
         loadMore
             .sink { [weak self] in
-                self?.loadNextPage()
+                self?.loadMorePosts()
             }
             .store(in: &cancellables)
     }
@@ -53,55 +55,67 @@ final class MyPostsViewModel: ObservableObject {
     
     private func refresh() {
         currentPage = 1
-        isLastPage = false
+        hasMorePages = true
         posts = []
-        fetchMyPosts()
+        fetchMyPosts(isInitialLoad: true)
     }
     
-    private func loadNextPage() {
-        guard !isLoading, !isLastPage else { return }
+    func loadMorePosts() {
+        guard hasMorePages && !isLoadingMore && !isLoading else { return }
         currentPage += 1
-        fetchMyPosts()
+        fetchMyPosts(isInitialLoad: false)
     }
     
-    private func fetchMyPosts() {
-        isLoading = true
+    private func fetchMyPosts(isInitialLoad: Bool = false) {
+        if isInitialLoad {
+            isLoading = true
+        } else {
+            isLoadingMore = true
+        }
         
-        let type = convertFilterToPostType(currentFilter)
+        let type = convertFilterToType(currentFilter)
         
-        feedRepository.fetchPosts(type: type, page: currentPage, pageSize: pageSize, diagnosis: nil, mood: nil)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] completion in
-                self?.isLoading = false
-                if case .failure(let error) = completion {
-                    self?.error = error
-                }
-            } receiveValue: { [weak self] response in
-                guard let self = self else { return }
-                
-                // TODO: 서버에서 현재 사용자의 게시글만 필터링해서 반환하는 API가 있다면 사용
-                // 현재는 모든 공유된 포스트를 받아오므로, 클라이언트에서 필터링 필요
-                // 또는 별도의 내 게시글 조회 API 추가 필요
-                
-                if self.currentPage == 1 {
-                    self.posts = response.posts
-                } else {
-                    self.posts.append(contentsOf: response.posts)
-                }
-                
-                self.isLastPage = self.currentPage >= response.pagination.totalPages
+        feedRepository.fetchMyPosts(
+            type: type,
+            page: currentPage,
+            pageSize: pageSize,
+            sort: "createdAt",
+            order: "desc",
+            diagnosis: nil,
+            fromDate: nil,
+            toDate: nil
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] completion in
+            self?.isLoading = false
+            self?.isLoadingMore = false
+            if case .failure(let error) = completion {
+                self?.error = error
+                Logger.network.error("내가 쓴 글 조회 실패: \(error.localizedDescription)")
             }
-            .store(in: &cancellables)
+        } receiveValue: { [weak self] response in
+            guard let self = self else { return }
+            
+            if isInitialLoad {
+                self.posts = response.posts
+            } else {
+                self.posts.append(contentsOf: response.posts)
+            }
+            
+            self.hasMorePages = response.pagination.currentPage < response.pagination.totalPages
+            self.currentPage = response.pagination.currentPage
+        }
+        .store(in: &cancellables)
     }
     
     // MARK: - Helpers
     
-    private func convertFilterToPostType(_ filter: String) -> PostType {
+    private func convertFilterToType(_ filter: String) -> String? {
         switch filter {
-        case "전체": return .all
-        case "일상 기록": return .daily
-        case "치료 기록": return .wellness
-        default: return .all
+        case "전체": return "all"
+        case "일상 기록": return "daily"
+        case "치료 기록": return "wellness"
+        default: return "all"
         }
     }
 }

--- a/ieum/Presentation/Main/MyPage/ViewModel/RadiationHistoryViewModel.swift
+++ b/ieum/Presentation/Main/MyPage/ViewModel/RadiationHistoryViewModel.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Combine
+import OSLog
+
+final class RadiationHistoryViewModel: ObservableObject {
+    
+    // MARK: - Inputs
+    
+    let didTapAddHistory = PassthroughSubject<Void, Never>()
+    let didTapDeleteHistory = PassthroughSubject<Int, Never>()
+    let didUpdateStartDate = PassthroughSubject<(index: Int, date: Date), Never>()
+    let didUpdateEndDate = PassthroughSubject<(index: Int, date: Date), Never>()
+    let didToggleInProgress = PassthroughSubject<(index: Int, isInProgress: Bool), Never>()
+    let didChangePrivacy = PassthroughSubject<Bool, Never>()
+    let didTapComplete = PassthroughSubject<Void, Never>()
+    
+    // MARK: - Outputs
+    
+    @Published private(set) var historyItems: [RadiationHistoryItem] = []
+    @Published private(set) var isPrivate: Bool = false
+    @Published private(set) var isCompleteButtonEnabled = false
+    
+    // MARK: - Navigation Events
+    
+    let navigateToComplete = PassthroughSubject<([RadiationTherapyRequest], Bool), Never>()
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    init() {
+        bindInputs()
+    }
+    
+    private func bindInputs() {
+        didTapAddHistory
+            .sink { [weak self] in
+                self?.addHistoryItem()
+            }
+            .store(in: &cancellables)
+        
+        didTapDeleteHistory
+            .sink { [weak self] index in
+                self?.deleteHistoryItem(at: index)
+            }
+            .store(in: &cancellables)
+        
+        didUpdateStartDate
+            .sink { [weak self] index, date in
+                self?.updateStartDate(at: index, date: date)
+            }
+            .store(in: &cancellables)
+        
+        didUpdateEndDate
+            .sink { [weak self] index, date in
+                self?.updateEndDate(at: index, date: date)
+            }
+            .store(in: &cancellables)
+        
+        didToggleInProgress
+            .sink { [weak self] index, isInProgress in
+                self?.toggleInProgress(at: index, isInProgress: isInProgress)
+            }
+            .store(in: &cancellables)
+        
+        didChangePrivacy
+            .sink { [weak self] isPrivate in
+                self?.isPrivate = isPrivate
+            }
+            .store(in: &cancellables)
+        
+        didTapComplete
+            .sink { [weak self] in
+                self?.complete()
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Methods
+    
+    func setupInitialData(_ radiations: [RadiationTherapy]?) {
+        guard let radiations = radiations, !radiations.isEmpty else {
+            addHistoryItem()
+            return
+        }
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        
+        historyItems = radiations.map { radiation in
+            let startDate = formatter.date(from: radiation.startDate)
+            let endDate = radiation.endDate.flatMap { formatter.date(from: $0) }
+            let isInProgress = endDate == nil
+            
+            return RadiationHistoryItem(
+                startDate: startDate,
+                endDate: endDate,
+                isInProgress: isInProgress
+            )
+        }
+        
+        updateCompleteButtonState()
+    }
+    
+    private func addHistoryItem() {
+        historyItems.append(RadiationHistoryItem(startDate: nil, endDate: nil, isInProgress: false))
+        updateCompleteButtonState()
+    }
+    
+    private func deleteHistoryItem(at index: Int) {
+        guard index < historyItems.count else { return }
+        historyItems.remove(at: index)
+        updateCompleteButtonState()
+    }
+    
+    private func updateStartDate(at index: Int, date: Date) {
+        guard index < historyItems.count else { return }
+        historyItems[index].startDate = date
+        updateCompleteButtonState()
+    }
+    
+    private func updateEndDate(at index: Int, date: Date) {
+        guard index < historyItems.count else { return }
+        historyItems[index].endDate = date
+        updateCompleteButtonState()
+    }
+    
+    private func toggleInProgress(at index: Int, isInProgress: Bool) {
+        guard index < historyItems.count else { return }
+        historyItems[index].isInProgress = isInProgress
+        if isInProgress {
+            historyItems[index].endDate = nil
+        }
+        updateCompleteButtonState()
+    }
+    
+    private func updateCompleteButtonState() {
+        let hasValidItems = historyItems.contains { item in
+            item.startDate != nil && (item.isInProgress || item.endDate != nil)
+        }
+        isCompleteButtonEnabled = hasValidItems
+    }
+    
+    private func complete() {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        
+        let radiationRequests = historyItems.compactMap { item -> RadiationTherapyRequest? in
+            guard let startDate = item.startDate else { return nil }
+            
+            let endDateString: String?
+            if item.isInProgress {
+                endDateString = nil
+            } else if let endDate = item.endDate {
+                endDateString = formatter.string(from: endDate)
+            } else {
+                return nil
+            }
+            
+            return RadiationTherapyRequest(
+                startDate: formatter.string(from: startDate),
+                endDate: endDateString
+            )
+        }
+        
+        navigateToComplete.send((radiationRequests, isPrivate))
+    }
+}

--- a/ieum/Presentation/Main/MyPage/ViewModel/SurgeryHistoryViewModel.swift
+++ b/ieum/Presentation/Main/MyPage/ViewModel/SurgeryHistoryViewModel.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Combine
+import OSLog
+
+final class SurgeryHistoryViewModel: ObservableObject {
+    
+    // MARK: - Inputs
+    
+    let didTapAddHistory = PassthroughSubject<Void, Never>()
+    let didTapDeleteHistory = PassthroughSubject<Int, Never>()
+    let didUpdateDate = PassthroughSubject<(index: Int, date: Date), Never>()
+    let didUpdateDescription = PassthroughSubject<(index: Int, description: String), Never>()
+    let didChangePrivacy = PassthroughSubject<Bool, Never>()
+    let didTapComplete = PassthroughSubject<Void, Never>()
+    
+    // MARK: - Outputs
+    
+    @Published private(set) var historyItems: [SurgeryHistoryItem] = []
+    @Published private(set) var isPrivate: Bool = false
+    @Published private(set) var isCompleteButtonEnabled = false
+    
+    // MARK: - Navigation Events
+    
+    let navigateToComplete = PassthroughSubject<([SurgeryRequest], Bool), Never>()
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    init() {
+        bindInputs()
+    }
+    
+    private func bindInputs() {
+        didTapAddHistory
+            .sink { [weak self] in
+                self?.addHistoryItem()
+            }
+            .store(in: &cancellables)
+        
+        didTapDeleteHistory
+            .sink { [weak self] index in
+                self?.deleteHistoryItem(at: index)
+            }
+            .store(in: &cancellables)
+        
+        didUpdateDate
+            .sink { [weak self] index, date in
+                self?.updateDate(at: index, date: date)
+            }
+            .store(in: &cancellables)
+        
+        didUpdateDescription
+            .sink { [weak self] index, description in
+                self?.updateDescription(at: index, description: description)
+            }
+            .store(in: &cancellables)
+        
+        didChangePrivacy
+            .sink { [weak self] isPrivate in
+                self?.isPrivate = isPrivate
+            }
+            .store(in: &cancellables)
+        
+        didTapComplete
+            .sink { [weak self] in
+                self?.complete()
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Methods
+    
+    func setupInitialData(_ surgeries: [Surgery]?) {
+        guard let surgeries = surgeries, !surgeries.isEmpty else {
+            addHistoryItem()
+            return
+        }
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        
+        historyItems = surgeries.map { surgery in
+            let date = formatter.date(from: surgery.date)
+            return SurgeryHistoryItem(date: date, description: surgery.description)
+        }
+        
+        updateCompleteButtonState()
+    }
+    
+    private func addHistoryItem() {
+        historyItems.append(SurgeryHistoryItem(date: nil, description: ""))
+        updateCompleteButtonState()
+    }
+    
+    private func deleteHistoryItem(at index: Int) {
+        guard index < historyItems.count else { return }
+        historyItems.remove(at: index)
+        updateCompleteButtonState()
+    }
+    
+    private func updateDate(at index: Int, date: Date) {
+        guard index < historyItems.count else { return }
+        historyItems[index].date = date
+        updateCompleteButtonState()
+    }
+    
+    private func updateDescription(at index: Int, description: String) {
+        guard index < historyItems.count else { return }
+        historyItems[index].description = description
+        updateCompleteButtonState()
+    }
+    
+    private func updateCompleteButtonState() {
+        let hasValidItems = historyItems.contains { item in
+            item.date != nil && !item.description.isEmpty
+        }
+        isCompleteButtonEnabled = hasValidItems
+    }
+    
+    private func complete() {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        
+        let surgeryRequests = historyItems.compactMap { item -> SurgeryRequest? in
+            guard let date = item.date, !item.description.isEmpty else { return nil }
+            return SurgeryRequest(date: formatter.string(from: date), description: item.description)
+        }
+        
+        navigateToComplete.send((surgeryRequests, isPrivate))
+    }
+}


### PR DESCRIPTION
## 💡 작업 요약
마이페이지의 전체 기능을 구현하고 API 연동을 완료했습니다. 프로필 조회/수정, 이력 관리, 내가 쓴 글 목록, 설정 기능(개인정보 처리방침, 로그아웃, 회원탈퇴)을 포함합니다.

## 🛠️ 작업 내용

### 1. 마이페이지 헤더 UI 개선
- [x] 탭 버튼을 좌측 정렬로 변경 (`fillEqually` → `fill`)
- [x] 우측 끝에 설정 버튼(톱니바퀴 아이콘) 추가
- [x] 선택된 탭 버튼 너비에 맞게 인디케이터 동작하도록 수정

### 2. 프로필 조회 및 표시
- [x] `AuthRepository.getProfile()` 메서드로 사용자 프로필 조회
- [x] 수술/항암/방사선 이력이 있을 경우 실제 데이터 표시
  - 수술 이력: `날짜: 설명` 형식
  - 항암 이력: `N차 (시작일 ~ 종료일/진행중)` 형식
  - 방사선 이력: `시작일 ~ 종료일/진행중` 형식
- [x] 비공개 상태일 때 닫힌 자물쇠(lock.fill) 아이콘 표시

### 3. 프로필 수정 기능
- [x] 진단명 수정: `SignUpStep4ViewController` 재사용
- [x] 연령대 수정: `SignUpStep5ViewController` 재사용
- [x] 지역 수정: `SignUpStep6ViewController` 재사용
- [x] 프로필 업데이트 API 연동: `PATCH /api/v1/users/profile`
- [x] `createUpdateRequest` 메서드로 변경된 필드만 포함한 요청 생성

### 4. 수술/항암/방사선 이력 수정 UI 구현
- [x] `SurgeryHistoryViewController`: 수술 이력 편집 화면
- [x] `ChemotherapyHistoryViewController`: 항암 이력 편집 화면 (차수, 진행중 상태 포함)
- [x] `RadiationHistoryViewController`: 방사선 이력 편집 화면 (진행중 상태 포함)
- [x] 공통 컴포넌트 구현:
  - `DatePickerInputView`: 날짜 선택 (Sheet 스타일, 오늘까지만 선택 가능)
  - `PrivacyChip`: 비공개 설정 체크박스 칩
  - `InProgressChip`: 진행중 상태 체크박스 칩
- [x] UICollectionView 사용: 이력 항목별 셀 + 스와이프 삭제 기능

### 5. 내가 쓴 글 목록
- [x] 게시글 목록 API 연동: `GET /api/v1/users/posts`
- [x] 페이지네이션을 통한 무한 스크롤 구현
- [x] 내가 쓴 글 화면에서 불필요한 필터 칩 제거

### 6. 설정 페이지 구현
- [x] `SettingsViewController` 생성 (정보/계정 섹션 분리)
- [x] 개인정보 처리방침: 노션 페이지를 WKWebView로 표시
- [x] 회원탈퇴: 확인 팝업 → `DELETE /api/v1/users/profile` API 연동 → 로그인 화면 전환
- [x] 로그아웃: 확인 팝업 → 토큰 삭제 → 로그인 화면 전환

### 7. 앱 전역 처리
- [x] `Notification.Name.userDidLogout` 정의
- [x] AppCoordinator에서 로그아웃 알림 관찰 및 로그인 화면 전환 처리

## 🎸 기타
- 프로필 수정 후 마이페이지 자동 새로고침
- 날짜 선택 시 미래 날짜 선택 불가 (수술/항암/방사선은 과거 이력)
- 회원탈퇴/로그아웃 시 안전하게 토큰 삭제 후 로그인 화면으로 전환

## ⚠️ 커밋 메시지 규칙 확인
- [x] `feat`: 새로운 기능 추가
- [x] `fix`: 버그 수정