### PR TITLE
fix: Apple 로그인 presentationAnchor iPad 호환 모드 대응

### DIFF
--- a/ieum/Data/Services/AppleLoginService.swift
+++ b/ieum/Data/Services/AppleLoginService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import UIKit
 import AuthenticationServices
 
 enum AppleLoginError: Error {
@@ -15,10 +16,12 @@ struct AppleLoginCredential {
 
 final class AppleLoginService: NSObject {
     private var loginSubject: PassthroughSubject<AppleLoginCredential, Error>?
+    private weak var presentationAnchor: UIWindow?
 
-    func login() -> AnyPublisher<AppleLoginCredential, Error> {
+    func login(presentationAnchor: UIWindow? = nil) -> AnyPublisher<AppleLoginCredential, Error> {
         let subject = PassthroughSubject<AppleLoginCredential, Error>()
         self.loginSubject = subject
+        self.presentationAnchor = presentationAnchor
 
         let provider = ASAuthorizationAppleIDProvider()
         let request = provider.createRequest()
@@ -65,9 +68,24 @@ extension AppleLoginService: ASAuthorizationControllerDelegate {
 
 extension AppleLoginService: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        return UIApplication.shared.connectedScenes
+        if let anchor = presentationAnchor {
+            return anchor
+        }
+
+        let activeScenes = UIApplication.shared.connectedScenes
+            .filter { $0.activationState == .foregroundActive }
             .compactMap { $0 as? UIWindowScene }
-            .flatMap { $0.windows }
-            .first { $0.isKeyWindow } ?? UIWindow()
+
+        let windows = activeScenes.flatMap { $0.windows }
+
+        if let keyWindow = windows.first(where: { $0.isKeyWindow }) {
+            return keyWindow
+        }
+
+        if let anyWindow = windows.first(where: { $0.rootViewController != nil }) {
+            return anyWindow
+        }
+
+        return ASPresentationAnchor()
     }
 }

--- a/ieum/Presentation/Auth/Login/View/LoginViewController.swift
+++ b/ieum/Presentation/Auth/Login/View/LoginViewController.swift
@@ -152,6 +152,6 @@ class LoginViewController: UIViewController {
     }
     
     @objc private func didTapAppleLogin() {
-        viewModel.didTapAppleLogin.send()
+        viewModel.didTapAppleLogin.send(view.window)
     }
 }

--- a/ieum/Presentation/Auth/Login/ViewModel/LoginViewModel.swift
+++ b/ieum/Presentation/Auth/Login/ViewModel/LoginViewModel.swift
@@ -1,10 +1,11 @@
 import Foundation
 import Combine
+import UIKit
 
 final class LoginViewModel: ObservableObject {
     // Inputs
     let didTapKakaoLogin = PassthroughSubject<Void, Never>()
-    let didTapAppleLogin = PassthroughSubject<Void, Never>()
+    let didTapAppleLogin = PassthroughSubject<UIWindow?, Never>()
     
     // Outputs
     @Published var isLoading = false
@@ -37,8 +38,8 @@ final class LoginViewModel: ObservableObject {
             .store(in: &cancellables)
         
         didTapAppleLogin
-            .sink { [weak self] in
-                self?.loginWithApple()
+            .sink { [weak self] anchor in
+                self?.loginWithApple(presentationAnchor: anchor)
             }
             .store(in: &cancellables)
     }
@@ -67,10 +68,10 @@ final class LoginViewModel: ObservableObject {
             .store(in: &cancellables)
     }
     
-    private func loginWithApple() {
+    private func loginWithApple(presentationAnchor: UIWindow?) {
         isLoading = true
-        
-        appleLoginService.login()
+
+        appleLoginService.login(presentationAnchor: presentationAnchor)
             .flatMap { [weak self] credential -> AnyPublisher<AppLoginResponse, Error> in
                 guard let self = self else { return Empty().eraseToAnyPublisher() }
                 return self.authRepository.loginWithApple(


### PR DESCRIPTION
- AppleLoginService에 presentationAnchor 주입 가능하도록 변경
- LoginViewController가 view.window를 직접 전달
- keyWindow fallback 실패 시 빈 UIWindow() 반환 제거
- foregroundActive scene 필터 + rootViewController 보유 window 우선

iPad 호환 모드/multi-scene 환경에서 Sign in with Apple 버튼 무반응 이슈 해결.

## 💡 작업 요약
<!-- 작업을 간략하게 요약해주세요 -->

## 🛠️ 작업 내용
<!-- 구체적인 작업 내용을 작성해주세요 -->
- [ ] 
- [ ] 

## 📷 스크린샷 (UI 변경사항인 경우)
| Before | After |
|:---:|:---:|
| <img src="" width="300" /> | <img src="" width="300" /> |

## 🎸 기타
<!-- 추가적으로 공유할 내용이 있다면 작성해주세요 -->

## ⚠️ 커밋 메시지 규칙 확인
<!-- 커밋 메시지 형식을 지켰는지 확인해주세요 -->
- [ ] `feat`: 새로운 기능 추가
- [ ] `fix`: 버그 수정
- [ ] `refactor`: 코드 리팩토링
- [ ] `style`: 코드 포맷팅, 세미콜론 누락 등
- [ ] `docs`: 문서 수정
- [ ] `test`: 테스트 추가 또는 수정
- [ ] `chore`: 빌드 업무, 패키지 매니저 설정 등
- [ ] `perf`: 성능 개선

