### PR TITLE
fix: Apple Sign in with Apple iPad 무반응 이슈 수정

### DIFF
--- a/ieum/Data/Services/AppleLoginService.swift
+++ b/ieum/Data/Services/AppleLoginService.swift
@@ -17,6 +17,7 @@ struct AppleLoginCredential {
 final class AppleLoginService: NSObject {
     private var loginSubject: PassthroughSubject<AppleLoginCredential, Error>?
     private weak var presentationAnchor: UIWindow?
+    private var authorizationController: ASAuthorizationController?
 
     func login(presentationAnchor: UIWindow? = nil) -> AnyPublisher<AppleLoginCredential, Error> {
         let subject = PassthroughSubject<AppleLoginCredential, Error>()
@@ -30,6 +31,7 @@ final class AppleLoginService: NSObject {
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self
         controller.presentationContextProvider = self
+        self.authorizationController = controller
         controller.performRequests()
 
         return subject.eraseToAnyPublisher()


### PR DESCRIPTION
## Summary

- `ASAuthorizationController`를 로컬 변수로 선언해 `performRequests()` 직후 ARC 해제되던 버그 수정
- `authorizationController` 프로퍼티로 강한 참조 유지
- iPad 호환 모드에서 시스템이 내부 retain 안 해줘 시트 미표시 → 먹통 현상 발생

## Root Cause

```swift
// Before: 함수 끝나면 즉시 해제
let controller = ASAuthorizationController(...)
controller.performRequests()

// After: 프로퍼티로 유지
self.authorizationController = controller
controller.performRequests()
```

## Test Plan

- [ ] iPad 실기기(iPad Air M3 등)에서 Apple 로그인 버튼 탭 → 시트 정상 표시 확인
- [ ] iPhone에서 Apple 로그인 정상 동작 확인 (regression 없음)
- [ ] 로그인 성공/취소 두 케이스 모두 확인

## Context

App Store 리젝 사유: Guideline 2.1(a) — iPad Air M3 / iPadOS 26.5에서 Sign in with Apple 무반응