### PR TITLE
fix: Apple Sign In 에러 Alert 표시

### DIFF
--- a/ieum/Presentation/Auth/Login/View/LoginViewController.swift
+++ b/ieum/Presentation/Auth/Login/View/LoginViewController.swift
@@ -140,7 +140,16 @@ class LoginViewController: UIViewController {
             .sink { [weak self] isLoading in
                 self?.kakaoLoginButton.isEnabled = !isLoading
                 self?.appleLoginButton.isEnabled = !isLoading
-                // 필요하다면 로딩 인디케이터 표시
+            }
+            .store(in: &cancellables)
+
+        viewModel.$error
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] error in
+                let alert = UIAlertController(title: "로그인 실패", message: error.localizedDescription, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "확인", style: .default))
+                self?.present(alert, animated: true)
             }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
## Summary

- `LoginViewController`에서 `viewModel.$error` 구독 누락으로 Apple Sign In 실패 시 아무런 피드백 없이 화면 멈춤
- 에러 발생 시 Alert 표시하도록 추가
- App Store 심사에서 리뷰어가 에러 내용 확인 가능해져 디버깅 가능

## Test plan

- [ ] Apple Sign In 정상 플로우 → 기존과 동일하게 동작
- [ ] Apple Sign In 실패 시 (취소 제외) → "로그인 실패" Alert 노출
- [ ] TestFlight 빌드로 iPad/iPhone 재확인