### PR TITLE
fix(network): BaseURL // 중복 방지 (Apple 리젝 대응)

### DIFF
--- a/ieum/Data/Network/API/APIService.swift
+++ b/ieum/Data/Network/API/APIService.swift
@@ -14,7 +14,9 @@ final class APIService {
     }
     
     var baseURL: String {
-        return Bundle.main.object(forInfoDictionaryKey: "BaseURL") as? String ?? ""
+        let raw = Bundle.main.object(forInfoDictionaryKey: "BaseURL") as? String ?? ""
+        // endpoint가 "/"로 시작하므로 trailing slash 제거해 "//" 중복 방지
+        return raw.replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
     }
     
     /// 공통 비동기 요청 메서드 (Concurrency + Logging) - 파라미터 있음

--- a/ieum/Data/Network/Interceptors/AuthInterceptor.swift
+++ b/ieum/Data/Network/Interceptors/AuthInterceptor.swift
@@ -6,7 +6,9 @@ final class AuthInterceptor: RequestInterceptor {
     private let baseURL: String
     
     init() {
-        self.baseURL = Bundle.main.object(forInfoDictionaryKey: "BaseURL") as? String ?? ""
+        let raw = Bundle.main.object(forInfoDictionaryKey: "BaseURL") as? String ?? ""
+        // endpoint가 "/"로 시작하므로 trailing slash 제거해 "//" 중복 방지
+        self.baseURL = raw.replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
     }
     
     func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {


### PR DESCRIPTION
## 문제
요청 URL에 `//`가 들어가 Apple 심사 리젝.
`https://firstback.ieummvp.shop//api/v1/...` 처럼 host와 endpoint 사이 `//` 중복.

## 원인 (2곳, 같은 trailing slash 버그)
1. **Xcode Cloud** `ci_scripts/ci_post_clone.sh` — TestFlight 빌드의 실제 xcconfig 생성 스크립트. `BASE_URL = https:$(SLASH)/$BASE_URL_HOST/` 처럼 host 뒤 `/` 박혀있음. (`$BASE_URL_HOST` = Xcode Cloud 환경변수, App Store Connect 설정. GitHub Secret 아님)
2. 로컬 `Configs/*.xcconfig` — 동일 trailing slash (gitignore라 커밋 미포함, 로컬 직접 수정함)

xcconfig는 `//`를 주석 처리하므로 `$(SLASH)` 변수 트릭 사용 중 — 트릭은 정상, 끝 slash 하나가 잉여.

## 수정
- `ci_post_clone.sh`: host 뒤 trailing `/` 제거 → **TestFlight 빌드 정상화**
- `APIService.baseURL` / `AuthInterceptor.baseURL`: trailing slash 정규식(`/+$`) 제거 → 코드 레벨 재발 방지(이중 안전장치)

## 영향
- `request` / `requestNoContent` / `upload` / 토큰 refresh URL 전부 정상.
- 머지 후 Xcode Cloud가 main 빌드 → TestFlight 업로드 시 올바른 URL 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)