### PR TITLE
fix(ci): Xcode Cloud xcconfig trailing slash 제거

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -5,9 +5,10 @@ REPO="$CI_PRIMARY_REPOSITORY_PATH"
 mkdir -p "$REPO/Configs"
 
 # SLASH trick: xcconfig treats // as comment, so split https://
+# trailing slash 금지: endpoint가 "/"로 시작해 "//" 중복되므로 host 뒤에 / 안 붙임
 cat > "$REPO/Debug.xcconfig" <<EOF
 KAKAO_APP_KEY = $KAKAO_APP_KEY
-BASE_URL = https:\$(SLASH)/$BASE_URL_HOST/
+BASE_URL = https:\$(SLASH)/$BASE_URL_HOST
 SLASH = /
 EOF
 


### PR DESCRIPTION
## 배경
PR #20에서 코드 레벨 가드는 머지됨. 이건 **근본 원인(xcconfig 생성 스크립트)** 마저 수정.

## 문제
`ci_scripts/ci_post_clone.sh`가 TestFlight 빌드용 xcconfig를 생성할 때
`BASE_URL = https:$(SLASH)/$BASE_URL_HOST/` 로 host 뒤 trailing `/`를 붙임 → 요청 URL `//` 중복.

## 수정
host 뒤 trailing `/` 제거. 코드 가드(#20)와 함께 이중 안전장치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)